### PR TITLE
32 Add license app with Django views from the ScanCode.io UI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 
 ### v1.0.4 (unreleased)
 
+- Add minimal license list and text views
+  https://github.com/nexB/scancode.io/issues/32
+
 - Improve Admin UI for efficient review:
   display, navigation, filters, and ability to view file content
   https://github.com/nexB/scancode.io/issues/36

--- a/scancodeio/licenses.py
+++ b/scancodeio/licenses.py
@@ -64,7 +64,7 @@ def license_details_view(request, key):
         text = licenses[key].text
     except KeyError:
         return HttpResponse(f"License {key} not found.")
-    return HttpResponse(f"<pre>{data}</pre>\n==============\n<pre>{text}</pre>")
+    return HttpResponse(f"<pre>{data}</pre><hr><pre>{text}</pre>")
 
 
 urls = [


### PR DESCRIPTION
This PR is about making the licenses data available from the ScanCode.io server UI.