### PR TITLE
Add support for setting SQLite as database backend #56

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BLACK_ARGS=--exclude="migrations|data|docs" .
 GET_SECRET_KEY=`${PYTHON_EXE} -c "from django.core.management import utils; print(utils.get_random_secret_key())"`
 # Customize with `$ make envfile ENV_FILE=/etc/scancodeio/.env`
 ENV_FILE=.env
-# Customize with `$ make cleandb SCANCODEIO_DB_PASSWORD=YOUR_PASSWORD`
+# Customize with `$ make postgres SCANCODEIO_DB_PASSWORD=YOUR_PASSWORD`
 SCANCODEIO_DB_PASSWORD=scancodeio
 
 # Use sudo for postgres, but only on Linux
@@ -82,29 +82,36 @@ black:
 valid: isort black
 
 clean:
-	@echo "-> Cleaning the Python env"
+	@echo "-> Clean the Python env"
 	rm -rf bin/ lib/ lib64/ include/ build/ dist/ pip-selfcheck.json pyvenv.cfg scancodeio.egg-info
 	find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
 
 migrate:
-	@echo "-> Applying migrations"
+	@echo "-> Apply database migrations"
 	${MANAGE} migrate
 
-cleandb:
+postgres:
+	@echo "-> Configure PostgreSQL database"
 	@echo "-> Create database user 'scancodeio'"
 	${SUDO_POSTGRES} createuser --no-createrole --no-superuser --login --inherit --createdb scancodeio || true
 	${SUDO_POSTGRES} psql -c "alter user scancodeio with encrypted password '${SCANCODEIO_DB_PASSWORD}';" || true
-	@echo "-> Dropping 'scancodeio' database"
+	@echo "-> Drop 'scancodeio' database"
 	${SUDO_POSTGRES} dropdb scancodeio || true
-	@echo "-> Creating 'scancodeio' database"
+	@echo "-> Create 'scancodeio' database"
 	${SUDO_POSTGRES} createdb --encoding=utf-8 --owner=scancodeio scancodeio
+	@$(MAKE) migrate
+
+sqlite:
+	@echo "-> Configure SQLite database"
+	@echo SCANCODEIO_DB_ENGINE=\"django.db.backends.sqlite3\" >> ${ENV_FILE}
+	@echo SCANCODEIO_DB_NAME=\"sqlite3.db\" >> ${ENV_FILE}
 	@$(MAKE) migrate
 
 run:
 	${MANAGE} runserver 8001
 
 test:
-	@echo "-> Running the test suite"
+	@echo "-> Run the test suite"
 	${MANAGE} test --noinput
 
 package: conf
@@ -123,4 +130,4 @@ docs:
 	rm -rf docs/_build/
 	sphinx-build docs/ docs/_build/
 
-.PHONY: conf dev envfile install check valid isort clean migrate cleandb run test package bump docs
+.PHONY: conf dev envfile install check valid isort clean migrate postgres sqlite run test package bump docs

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,18 +15,37 @@ Local installation
 ------------------
 
 Clone the git `ScanCode.io repo <https://github.com/nexB/scancode.io>`_,
-install dependencies, and prepare the database::
+install dependencies and create an environment file::
 
     git clone git@github.com:nexB/scancode.io.git && cd scancode.io
     make dev
     make envfile
-    make cleandb
 
 .. note::
     The Python version can be specified using the following command during the
     ``make dev`` step::
 
         make dev PYTHON_EXE=python3.8
+
+Database
+--------
+
+**PostgreSQL** is the preferred database backend and should always be used on
+production servers.
+
+Create the PostgreSQL user, database, and table with::
+
+    make postgres
+
+Alternatively, you can also decide to use a **SQLite** database for local
+development as a single user::
+
+    make sqlite
+
+.. warning::
+    Choosing SQLite over PostgreSQL has some caveats. See
+    https://docs.djangoproject.com/en/dev/ref/databases/#sqlite-notes
+    for details.
 
 Tests
 -----

--- a/docs/offline-installation.rst
+++ b/docs/offline-installation.rst
@@ -24,7 +24,7 @@ On the offline install server:
    tar -xf scancodeio-1.0.4.tar.gz && cd scancode.io
    make install
    make envfile
-   make cleandb
+   make postgres
 
 Offline Upgrade
 ---------------

--- a/scancodeio/settings/base.py
+++ b/scancodeio/settings/base.py
@@ -20,11 +20,25 @@
 # ScanCode.io is a free software code scanning tool from nexB Inc. and others.
 # Visit https://github.com/nexB/scancode.io for support and download.
 
-import os
 import sys
 from pathlib import Path
 
 import environ
+
+# Environment
+
+env_file = "/etc/scancodeio/.env"
+if not Path(env_file).exists():
+    env_file = ".env"
+
+environ.Env.read_env(env_file)
+env = environ.Env()
+
+SECRET_KEY = env.str("SECRET_KEY")
+
+# ScanCode.io
+
+SCANCODE_DEFAULT_OPTIONS = env.list("SCANCODE_DEFAULT_OPTIONS", default=[])
 
 # Application definition
 
@@ -64,11 +78,11 @@ WSGI_APPLICATION = "scancodeio.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "HOST": os.getenv("SCANCODEIO_DB_HOST", "localhost"),
-        "NAME": os.getenv("SCANCODEIO_DB_NAME", "scancodeio"),
-        "USER": os.getenv("SCANCODEIO_DB_USER", "scancodeio"),
-        "PASSWORD": os.getenv("SCANCODEIO_DB_PASSWORD", "scancodeio"),
+        "ENGINE": env.str("SCANCODEIO_DB_ENGINE", "django.db.backends.postgresql"),
+        "HOST": env.str("SCANCODEIO_DB_HOST", "localhost"),
+        "NAME": env.str("SCANCODEIO_DB_NAME", "scancodeio"),
+        "USER": env.str("SCANCODEIO_DB_USER", "scancodeio"),
+        "PASSWORD": env.str("SCANCODEIO_DB_PASSWORD", "scancodeio"),
         "PORT": "5432",
         "ATOMIC_REQUESTS": True,
     }
@@ -127,7 +141,7 @@ LOGGING = {
     "loggers": {
         "scanner.tasks": {
             "handlers": ["console"],
-            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+            "level": env.str("DJANGO_LOG_LEVEL", "INFO"),
         },
     },
 }
@@ -188,18 +202,3 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 50,
     "UPLOADED_FILES_USE_URL": False,
 }
-
-# Environment and custom settings, keep last
-
-env_file = "/etc/scancodeio/.env"
-if not Path(env_file).exists():
-    env_file = ".env"
-
-environ.Env.read_env(env_file)
-env = environ.Env()
-
-SECRET_KEY = env.str("SECRET_KEY")
-
-# ScanCode.io custom settings
-
-SCANCODE_DEFAULT_OPTIONS = env.list("SCANCODE_DEFAULT_OPTIONS", default=[])


### PR DESCRIPTION
Replace `cleandb` by 2 explicit `postgres` and `sqlite` commands.

Signed-off-by: Thomas Druez <tdruez@nexb.com>