### PR TITLE
Implement cache to prevent duplicated resources scanning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 
 ### v1.1.1 (unreleased)
 
+- Implement cache to prevent scanning multiple times a duplicated codebase resource.
+  https://github.com/nexB/scancode.io/issues/70
+
 - Create the virtualenv using the virtualenv.pyz app in place of the bundled "venv".
   https://github.com/nexB/scancode.io/issues/104
 

--- a/scancodeio/settings/base.py
+++ b/scancodeio/settings/base.py
@@ -132,6 +132,24 @@ AUTH_PASSWORD_VALIDATORS = [
 # True if running tests through `./manage test`
 IS_TESTS = "test" in sys.argv
 
+# Cache
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "default",
+    },
+    "scan_results": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "scan",
+        "TIMEOUT": 86_400,  # 1 day
+        "OPTIONS": {
+            # Maximum entries allowed in the cache before old values are deleted
+            "MAX_ENTRIES": 1_000_000,
+        },
+    },
+}
+
 # Logging
 
 LOGGING = {

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -684,6 +684,33 @@ class ScanFieldsModelMixin(models.Model):
     class Meta:
         abstract = True
 
+    @classmethod
+    def scan_fields(cls):
+        return [field.name for field in ScanFieldsModelMixin._meta.get_fields()]
+
+    def set_scan_results(self, scan_results, save=False):
+        """
+        Set the values from `scan_results` on this instance scan related fields.
+        """
+        scan_fields = self.scan_fields()
+        for field_name, value in scan_results.items():
+            if value and field_name in scan_fields:
+                setattr(self, field_name, value)
+
+        if save:
+            self.save()
+
+    def copy_scan_results(self, from_instance, save=False):
+        """
+        Copy the scan related fields values from `from_instance`to this instance.
+        """
+        for field_name in self.scan_fields():
+            value_from_instance = getattr(from_instance, field_name)
+            setattr(self, field_name, value_from_instance)
+
+        if save:
+            self.save()
+
 
 class CodebaseResource(
     ProjectRelatedModel, ScanFieldsModelMixin, SaveProjectErrorMixin, AbstractResource
@@ -816,15 +843,6 @@ class CodebaseResource(
     @property
     def for_packages(self):
         return [str(package) for package in self.discovered_packages.all()]
-
-    def set_scan_results(self, scan_results, save=False):
-        model_fields = self.model_fields()
-        for field_name, value in scan_results.items():
-            if value and field_name in model_fields:
-                setattr(self, field_name, value)
-
-        if save:
-            self.save()
 
 
 class DiscoveredPackage(ProjectRelatedModel, SaveProjectErrorMixin, AbstractPackage):


### PR DESCRIPTION
This is a first step of performance optimizations. 
Next will be to improve the code efficiency and distribute the processing over the available resources (multiprocessing)

Signed-off-by: Thomas Druez <tdruez@nexb.com>