### PR TITLE
Use the common extraction API with extractcode for the Docker pipeline #70

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@
 
 ### v1.1.1 (unreleased)
 
+- Use the extractcode API for the Docker pipeline.
+  This change helps with performance and results consistency between pipelines.
+  https://github.com/nexB/scancode.io/issues/70
+
 - Implement cache to prevent scanning multiple times a duplicated codebase resource.
   https://github.com/nexB/scancode.io/issues/70
 

--- a/scanpipe/pipelines/docker.py
+++ b/scanpipe/pipelines/docker.py
@@ -20,10 +20,6 @@
 # ScanCode.io is a free software code scanning tool from nexB Inc. and others.
 # Visit https://github.com/nexB/scancode.io for support and download.
 
-from pathlib import Path
-
-from container_inspector.image import Image
-
 from scanpipe import pipes
 from scanpipe.pipelines import Pipeline
 from scanpipe.pipes import docker
@@ -40,39 +36,17 @@ class Docker(Pipeline):
         """
         Extract the images from tarballs.
         """
-        target_path = self.project.tmp_path
-        extract_errors = []
-        all_images = []
-
-        for input_tarball in self.project.inputs(pattern="*.tar*"):
-            extract_target = target_path / f"{input_tarball.name}-extract"
-            errors = scancode.extract(input_tarball, extract_target)
-            extract_errors.extend(errors)
-            all_images.extend(Image.get_images_from_dir(extract_target))
-
-        if extract_errors:
-            self.add_error("\n".join(extract_errors))
-
-        self.images = all_images
+        self.images, errors = docker.extract_images_from_inputs(self.project)
+        if errors:
+            self.add_error("\n".join(errors))
 
     def extract_layers(self):
         """
         Extract layers from images.
         """
-        extract_errors = []
-
-        for image in self.images:
-            image_dirname = Path(image.base_location).name
-            target_path = self.project.codebase_path / image_dirname
-
-            for layer in image.layers:
-                extract_target = target_path / layer.layer_id
-                errors = scancode.extract(layer.layer_location, extract_target)
-                extract_errors.extend(errors)
-                layer.extracted_to_location = str(extract_target)
-
-        if extract_errors:
-            self.add_error("\n".join(extract_errors))
+        errors = docker.extract_layers_from_images(self.project, self.images)
+        if errors:
+            self.add_error("\n".join(errors))
 
     def find_images_linux_distro(self):
         """

--- a/scanpipe/pipelines/docker.py
+++ b/scanpipe/pipelines/docker.py
@@ -85,6 +85,12 @@ class Docker(Pipeline):
         docker.tag_whiteout_codebase_resources(self.project)
         rootfs.tag_uninteresting_codebase_resources(self.project)
 
+    def tag_empty_files(self):
+        """
+        Flag empty files.
+        """
+        rootfs.tag_empty_codebase_resources(self.project)
+
     def scan_for_application_packages(self):
         """
         Scan unknown resources for packages infos.
@@ -117,6 +123,7 @@ class Docker(Pipeline):
         collect_and_create_codebase_resources,
         collect_and_create_system_packages,
         tag_uninteresting_codebase_resources,
+        tag_empty_files,
         scan_for_application_packages,
         scan_for_files,
         analyze_scanned_files,

--- a/scanpipe/pipelines/root_filesystems.py
+++ b/scanpipe/pipelines/root_filesystems.py
@@ -87,17 +87,17 @@ class RootFS(Pipeline):
         """
         rootfs.tag_uninteresting_codebase_resources(self.project)
 
+    def tag_empty_files(self):
+        """
+        Flag empty files.
+        """
+        rootfs.tag_empty_codebase_resources(self.project)
+
     def scan_for_application_packages(self):
         """
         Scan unknown resources for packages infos.
         """
         scancode.scan_for_application_packages(self.project)
-
-    def ignore_empty_files(self):
-        """
-        Skip and mark as ignored any empty file.
-        """
-        rootfs.tag_empty_codebase_resources(self.project)
 
     def match_not_analyzed_to_system_packages(self):
         """
@@ -145,8 +145,8 @@ class RootFS(Pipeline):
         collect_and_create_codebase_resources,
         collect_and_create_system_packages,
         tag_uninteresting_codebase_resources,
+        tag_empty_files,
         scan_for_application_packages,
-        ignore_empty_files,
         match_not_analyzed_to_system_packages,
         scan_for_files,
         analyze_scanned_files,

--- a/scanpipe/pipelines/root_filesystems.py
+++ b/scanpipe/pipelines/root_filesystems.py
@@ -22,8 +22,6 @@
 
 import os
 
-from extractcode.extract import extract_file
-
 from scanpipe import pipes
 from scanpipe.pipelines import Pipeline
 from scanpipe.pipes import rootfs
@@ -40,13 +38,11 @@ class RootFS(Pipeline):
         Extract root filesystem input archives with extractcode.
         """
         input_files = self.project.inputs("*")
-        target = str(self.project.codebase_path)
+        target_path = self.project.codebase_path
         extract_errors = []
 
         for input_file in input_files:
-            for event in extract_file(input_file, target):
-                if event.done:
-                    extract_errors.extend(event.errors)
+            extract_errors = scancode.extract(input_file, target_path)
 
         if extract_errors:
             self.add_error("\n".join(extract_errors))

--- a/scanpipe/pipes/docker.py
+++ b/scanpipe/pipes/docker.py
@@ -25,7 +25,6 @@ import posixpath
 from functools import partial
 from pathlib import Path
 
-from container_inspector.image import Image
 from container_inspector.rootfs import get_whiteout_marker_type
 
 from scanpipe import pipes
@@ -35,44 +34,44 @@ from scanpipe.pipes import rootfs
 logger = logging.getLogger(__name__)
 
 
-def get_images_from_extracted_codebase(project):
-    """
-    Yield images collected from the project "codebase" directory. The
-    image tarball should be extracted there first, with its manifest.json at the
-    root.
-    """
-    codebase = project.codebase_path.absolute()
-    for image in Image.get_images_from_dir(location=codebase):
-        yield image
-
-
-def get_and_extract_images_from_image_tarballs(project, force_extract=False):
-    """
-    Yield images collected from the project "codebase" directory.
-    The process is to:
-    1. collect all the tarballs from this directory.
-    2. for each, extract that under a -extract directory and collect its images.
-
-    If `force_extract` is False, do not extract if already extracted.
-    """
-    all_images = []
-
-    for tarball in project.inputs(pattern="*.tar*"):
-        tarball_location = str(tarball.absolute())
-        if tarball_location.endswith("-extract"):
-            continue
-        extracted_location = tarball_location + "-extract"
-        tarball_images = Image.get_images_from_tarball(
-            location=tarball_location,
-            target_dir=extracted_location,
-            force_extract=force_extract,
-        )
-
-        for image in tarball_images:
-            logger.info("Collected Docker image: {}".format(image.image_id))
-            all_images.append(image)
-
-    return all_images
+# def get_images_from_extracted_codebase(project):
+#     """
+#     Yield images collected from the project "codebase" directory. The
+#     image tarball should be extracted there first, with its manifest.json at the
+#     root.
+#     """
+#     codebase = project.codebase_path.absolute()
+#     for image in Image.get_images_from_dir(location=codebase):
+#         yield image
+#
+#
+# def get_and_extract_images_from_image_tarballs(project, force_extract=False):
+#     """
+#     Yield images collected from the project "codebase" directory.
+#     The process is to:
+#     1. collect all the tarballs from this directory.
+#     2. for each, extract that under a -extract directory and collect its images.
+#
+#     If `force_extract` is False, do not extract if already extracted.
+#     """
+#     all_images = []
+#
+#     for tarball in project.inputs(pattern="*.tar*"):
+#         tarball_location = str(tarball.absolute())
+#         if tarball_location.endswith("-extract"):
+#             continue
+#         extracted_location = tarball_location + "-extract"
+#         tarball_images = Image.get_images_from_tarball(
+#             location=tarball_location,
+#             target_dir=extracted_location,
+#             force_extract=force_extract,
+#         )
+#
+#         for image in tarball_images:
+#             logger.info("Collected Docker image: {}".format(image.image_id))
+#             all_images.append(image)
+#
+#     return all_images
 
 
 def get_image_data(image):

--- a/scanpipe/pipes/docker.py
+++ b/scanpipe/pipes/docker.py
@@ -25,53 +25,53 @@ import posixpath
 from functools import partial
 from pathlib import Path
 
+from container_inspector.image import Image
 from container_inspector.rootfs import get_whiteout_marker_type
 
 from scanpipe import pipes
 from scanpipe.models import CodebaseResource
 from scanpipe.pipes import rootfs
+from scanpipe.pipes import scancode
 
 logger = logging.getLogger(__name__)
 
 
-# def get_images_from_extracted_codebase(project):
-#     """
-#     Yield images collected from the project "codebase" directory. The
-#     image tarball should be extracted there first, with its manifest.json at the
-#     root.
-#     """
-#     codebase = project.codebase_path.absolute()
-#     for image in Image.get_images_from_dir(location=codebase):
-#         yield image
-#
-#
-# def get_and_extract_images_from_image_tarballs(project, force_extract=False):
-#     """
-#     Yield images collected from the project "codebase" directory.
-#     The process is to:
-#     1. collect all the tarballs from this directory.
-#     2. for each, extract that under a -extract directory and collect its images.
-#
-#     If `force_extract` is False, do not extract if already extracted.
-#     """
-#     all_images = []
-#
-#     for tarball in project.inputs(pattern="*.tar*"):
-#         tarball_location = str(tarball.absolute())
-#         if tarball_location.endswith("-extract"):
-#             continue
-#         extracted_location = tarball_location + "-extract"
-#         tarball_images = Image.get_images_from_tarball(
-#             location=tarball_location,
-#             target_dir=extracted_location,
-#             force_extract=force_extract,
-#         )
-#
-#         for image in tarball_images:
-#             logger.info("Collected Docker image: {}".format(image.image_id))
-#             all_images.append(image)
-#
-#     return all_images
+def extract_images_from_inputs(project):
+    """
+    Collect all the tarballs from the `project` input/ work directory, extract each
+    tarball to the tmp/ work directory and collect the images.
+    Return the `images` and `errors` that may have happen during the extraction.
+    """
+    target_path = project.tmp_path
+    images = []
+    errors = []
+
+    for input_tarball in project.inputs(pattern="*.tar*"):
+        extract_target = target_path / f"{input_tarball.name}-extract"
+        extract_errors = scancode.extract(input_tarball, extract_target)
+        images.extend(Image.get_images_from_dir(extract_target))
+        errors.extend(extract_errors)
+
+    return images, errors
+
+
+def extract_layers_from_images(project, images):
+    """
+    Extract all the layers from provided `images` into the `project` codebase/ work
+    directory.
+    Return the `errors` that may have happen during the extraction.
+    """
+    errors = []
+
+    for image in images:
+        image_dirname = Path(image.base_location).name
+        target_path = project.codebase_path / image_dirname
+
+        for layer in image.layers:
+            extract_target = target_path / layer.layer_id
+            extract_errors = scancode.extract(layer.layer_location, extract_target)
+            errors.extend(extract_errors)
+            layer.extracted_to_location = str(extract_target)
 
 
 def get_image_data(image):

--- a/scanpipe/pipes/rootfs.py
+++ b/scanpipe/pipes/rootfs.py
@@ -298,7 +298,7 @@ def match_not_analyzed(
 
 def tag_empty_codebase_resources(project):
     """
-    Tag remaining empty files as ignored
+    Tag empty files as ignored.
     """
     project.codebaseresources.select_for_update().filter(
         type__exact="file",
@@ -324,9 +324,7 @@ def tag_uninteresting_codebase_resources(project):
         "/proc/",
         "/dev/",
         "/run/",
-    ) + (
-        # alpine specific
-        "/lib/apk/db/",
+        "/lib/apk/db/",  # alpine specific
     )
 
     qs = project.codebaseresources.no_status()

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -30,6 +30,7 @@ from django.core.cache import caches
 import packagedcode
 from commoncode import fileutils
 from commoncode.resource import VirtualCodebase
+from extractcode.extract import extract_file
 from packageurl import PackageURL
 from scancode import ScancodeError
 from scancode import api as scancode_api
@@ -43,6 +44,19 @@ from scanpipe.models import DiscoveredPackage
 """
 Utilities to deal with ScanCode objects, in particular Codebase and Package.
 """
+
+
+def extract(location, target):
+    """
+    Wraps the `extractcode.extract_file` to execute the extraction and return errors.
+    """
+    errors = []
+
+    for event in extract_file(location, target):
+        if event.done:
+            errors.extend(event.errors)
+
+    return errors
 
 
 def get_resource_info(location):


### PR DESCRIPTION
With the following changes, the rootfs and the docker pipelines are now using the same extraction code.