### PR TITLE
Do not create Package if one of the required fields is missing...

### DIFF
--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -907,6 +907,16 @@ class CodebaseResource(
         numbered_lines = numbered_text_lines(self.location)
         return "".join(l for _, l in numbered_lines)
 
+    def create_and_add_package(self, package_data):
+        """
+        Create a DiscoveredPackage instance using the `package_data` and assign
+        it to this CodebaseResource instance.
+        """
+        created_package = DiscoveredPackage.create_from_data(self.project, package_data)
+        if created_package:
+            self.discovered_packages.add(created_package)
+            return created_package
+
     @property
     def for_packages(self):
         return [str(package) for package in self.discovered_packages.all()]
@@ -952,14 +962,3 @@ class DiscoveredPackage(ProjectRelatedModel, SaveProjectErrorMixin, AbstractPack
         }
 
         return cls.objects.create(project=project, **cleaned_package_data)
-
-    @classmethod
-    def create_for_resource(cls, package_data, codebase_resource):
-        """
-        Create a DiscoveredPackage instance using the `package_data` and assign
-        it to the provided `codebase_resource`.
-        """
-        project = codebase_resource.project
-        created_package = cls.create_from_data(project, package_data)
-        codebase_resource.discovered_packages.add(created_package)
-        return created_package

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -38,7 +38,6 @@ from scancode import api as scancode_api
 
 from scanpipe import pipes
 from scanpipe.models import CodebaseResource
-from scanpipe.models import DiscoveredPackage
 
 """
 Utilities to deal with ScanCode objects, in particular Codebase and Package.
@@ -177,8 +176,8 @@ def scan_package_and_save_results(codebase_resource):
     packages = package_info.get("packages", [])
 
     if packages:
-        for package in packages:
-            DiscoveredPackage.create_for_resource(package, codebase_resource)
+        for package_data in packages:
+            codebase_resource.create_and_add_package(package_data)
         codebase_resource.status = "application-package"
         codebase_resource.save()
 

--- a/scanpipe/tests/test_api.py
+++ b/scanpipe/tests/test_api.py
@@ -51,12 +51,10 @@ from scanpipe.tests import package_data1
 class ScanPipeAPITest(TransactionTestCase):
     def setUp(self):
         self.project1 = Project.objects.create(name="Analysis")
-        self.codebase_resource1 = CodebaseResource.objects.create(
+        self.resource1 = CodebaseResource.objects.create(
             project=self.project1, path="filename.ext"
         )
-        self.discovered_package1 = DiscoveredPackage.create_for_resource(
-            package_data1, self.codebase_resource1
-        )
+        self.discovered_package1 = self.resource1.create_and_add_package(package_data1)
 
         self.project_list_url = reverse("project-list")
         self.project1_detail_url = reverse("project-detail", args=[self.project1.uuid])
@@ -276,7 +274,7 @@ class ScanPipeAPITest(TransactionTestCase):
         expected = {"status": "Resource not found. Use ?path=<resource_path>"}
         self.assertEqual(expected, response.data)
 
-        response = self.csrf_client.get(url + f"?path={self.codebase_resource1.path}")
+        response = self.csrf_client.get(url + f"?path={self.resource1.path}")
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         expected = {"status": "File not available"}
         self.assertEqual(expected, response.data)

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -645,6 +645,14 @@ class ScanPipeModelsTest(TestCase):
             "gpl-2.0 AND gpl-2.0-plus AND unknown", package.license_expression
         )
 
+        package_count = DiscoveredPackage.objects.count()
+        missing_required_field = dict(package_data1)
+        missing_required_field["name"] = ""
+        self.assertIsNone(
+            DiscoveredPackage.create_from_data(self.project1, missing_required_field)
+        )
+        self.assertEqual(package_count, DiscoveredPackage.objects.count())
+
 
 class ScanPipeModelsTransactionTest(TransactionTestCase):
     """

--- a/scanpipe/tests/test_pipes.py
+++ b/scanpipe/tests/test_pipes.py
@@ -90,10 +90,7 @@ class ScanPipePipesTest(TestCase):
             project=project1,
             path="filename.ext",
         )
-        DiscoveredPackage.create_for_resource(
-            package_data1,
-            codebase_resource,
-        )
+        codebase_resource.create_and_add_package(package_data1)
 
         queryset = project1.discoveredpackages.all()
         fieldnames = ["purl", "name", "version"]
@@ -128,10 +125,7 @@ class ScanPipePipesTest(TestCase):
             project=project1,
             path="filename.ext",
         )
-        DiscoveredPackage.create_for_resource(
-            package_data1,
-            codebase_resource,
-        )
+        codebase_resource.create_and_add_package(package_data1)
 
         queryset = project1.discoveredpackages.all()
         fieldnames = ["purl", "name", "version"]
@@ -185,7 +179,7 @@ class ScanPipePipesTest(TestCase):
             project=project1,
             path="filename.ext",
         )
-        DiscoveredPackage.create_for_resource(package_data1, codebase_resource)
+        codebase_resource.create_and_add_package(package_data1)
 
         output_file = output.to_json(project=project1)
         self.assertEqual([output_file.name], project1.output_root)
@@ -206,7 +200,7 @@ class ScanPipePipesTest(TestCase):
             project=project1,
             path="filename.ext",
         )
-        DiscoveredPackage.create_for_resource(package_data1, codebase_resource)
+        codebase_resource.create_and_add_package(package_data1)
 
         output_file = output.to_xlsx(project=project1)
         self.assertEqual([output_file.name], project1.output_root)


### PR DESCRIPTION
...create a ProjectError instead.
Also, move the package creation from the DiscoveredPackage to the CodebaseResource model.

Signed-off-by: Thomas Druez <tdruez@nexb.com>