### PR TITLE
Create walk method for CodebaseResource and ProjectCodebase

### DIFF
--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -1100,12 +1100,16 @@ class CodebaseResource(
         Return a QuerySet of direct children CodebaseResource objects using a
         Database query on this CodebaseResource `path`.
 
+        Paths are returned in lower-cased sorted path order to reflect the
+        behavior of `commoncode.resource.Resource.children()`
+        https://github.com/nexB/commoncode/blob/76a03d9c1cd2a582dcec4351c768c3ef646e1b31/src/commoncode/resource.py#L1199
+
         `codebase` is not used in this context but required for compatibility
         with the commoncode.resource.VirtualCodebase class API.
         """
         exactly_one_sub_directory = "[^/]+$"
         children_regex = rf"^{self.path}/{exactly_one_sub_directory}"
-        return self.descendants().filter(path__regex=children_regex)
+        return self.descendants().filter(path__regex=children_regex).order_by(Lower('path'))
 
     def walk(self, topdown=True):
         """
@@ -1113,11 +1117,8 @@ class CodebaseResource(
 
         Walk the tree top-down, depth-first if `topdown` is True, otherwise walk
         bottom-up.
-
-        Each level is sorted by lowercased path, to reflect the walk behavior of
-        `commoncode.resource.Resource.walk()`
         """
-        for child in self.children().order_by(Lower('path')):
+        for child in self.children():
             if topdown:
                 yield child
             for subchild in child.walk(topdown=topdown):

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -35,6 +35,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.db.models import TextField
 from django.db.models.functions import Cast
+from django.db.models.functions import Lower
 from django.forms import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
@@ -1105,6 +1106,24 @@ class CodebaseResource(
         exactly_one_sub_directory = "[^/]+$"
         children_regex = rf"^{self.path}/{exactly_one_sub_directory}"
         return self.descendants().filter(path__regex=children_regex)
+
+    def walk(self, topdown=True):
+        """
+        Yield all descendant Resources of this Resource. Does not include self.
+
+        Walk the tree top-down, depth-first if `topdown` is True, otherwise walk
+        bottom-up.
+
+        Each level is sorted by lowercased path, to reflect the walk behavior of
+        `commoncode.resource.Resource.walk()`
+        """
+        for child in self.children().order_by(Lower('path')):
+            if topdown:
+                yield child
+            for subchild in child.walk(topdown=topdown):
+                yield subchild
+            if not topdown:
+                yield child
 
     def get_absolute_url(self):
         return reverse("resource_detail", args=[self.project_id, self.pk])

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -1122,7 +1122,7 @@ class CodebaseResource(
         Walk the tree top-down, depth-first if `topdown` is True, otherwise walk
         bottom-up.
         """
-        for child in self.children():
+        for child in self.children().iterator():
             if topdown:
                 yield child
             for subchild in child.walk(topdown=topdown):

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -1109,7 +1109,11 @@ class CodebaseResource(
         """
         exactly_one_sub_directory = "[^/]+$"
         children_regex = rf"^{self.path}/{exactly_one_sub_directory}"
-        return self.descendants().filter(path__regex=children_regex).order_by(Lower('path'))
+        return (
+            self.descendants()
+            .filter(path__regex=children_regex)
+            .order_by(Lower("path"))
+        )
 
     def walk(self, topdown=True):
         """

--- a/scanpipe/pipes/codebase.py
+++ b/scanpipe/pipes/codebase.py
@@ -76,8 +76,14 @@ class ProjectCodebase:
     def resources(self):
         return self.project.codebaseresources.all()
 
-    def walk(self):
-        yield from self.resources.iterator()
+    def walk(self, topdown=True):
+        root = self.root
+        if topdown:
+            yield root
+        for resource in root.walk(topdown=topdown):
+            yield resource
+        if not topdown:
+            yield root
 
     def get_tree(self):
         return get_tree(self.root, fields=["name", "path"])

--- a/scanpipe/tests/data/asgiref-3.3.0_walk_test_fixtures.json
+++ b/scanpipe/tests/data/asgiref-3.3.0_walk_test_fixtures.json
@@ -1,0 +1,889 @@
+[
+{
+  "model": "scanpipe.project",
+  "pk": "44915ce7-7664-42ff-8334-04399f844c04",
+  "fields": {
+    "created_date": "2020-11-25T14:56:55.306Z",
+    "name": "asgiref",
+    "work_directory": "var/tests/test-28536-44915ce7",
+    "extra_data": {}
+  }
+},
+{
+  "model": "scanpipe.run",
+  "pk": "5af1e1aa-8e95-4a28-a5ac-5d9adcd8afff",
+  "fields": {
+    "task_id": "bc395646-5925-44a4-ad41-f48bed5c120f",
+    "task_start_date": "2020-11-25T14:56:55.662Z",
+    "task_end_date": "2020-11-25T14:57:23.176Z",
+    "task_exitcode": 0,
+    "task_output": "Metaflow 2.2.5 executing ScanCodebase",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "pipeline_name": "scan_codebase",
+    "created_date": "2020-11-25T14:56:55.585Z",
+    "description": "A pipeline to scan a codebase with ScanCode-toolkit.\n\nThe input files are copied to the project codebase/ directory and extracted\nin place before running the scan.\nAlternatively, the code can be manually copied to the project codebase/\ndirectory."
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 42,
+  "fields": {
+    "path": "codebase",
+    "size": 0,
+    "sha1": "",
+    "md5": "",
+    "sha256": "",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "directory",
+    "extra_data": {},
+    "name": "codebase",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "",
+    "file_type": ""
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 43,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl",
+    "size": 19948,
+    "sha1": "c03f67211a311b13d1294ac8af7cb139ee34c4f9",
+    "md5": "5bce1df6dedc53a41a9a6b40d7b1699e",
+    "sha256": "a5098bc870b80e7b872bff60bb363c7f2c2c89078759f6c47b53ff8c525a152e",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "application-package",
+    "type": "file",
+    "extra_data": {},
+    "name": "asgiref-3.3.0.whl",
+    "extension": ".whl",
+    "programming_language": "",
+    "mime_type": "application/zip",
+    "file_type": "Zip archive data, at least v2.0 to extract"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 44,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract",
+    "size": 0,
+    "sha1": "",
+    "md5": "",
+    "sha256": "",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "directory",
+    "extra_data": {},
+    "name": "asgiref-3.3.0.whl-extract",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "",
+    "file_type": ""
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 45,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref",
+    "size": 0,
+    "sha1": "",
+    "md5": "",
+    "sha256": "",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "directory",
+    "extra_data": {},
+    "name": "asgiref",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "",
+    "file_type": ""
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 46,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/__init__.py",
+    "size": 22,
+    "sha1": "91bc786d907bf3ca8b8e6277063107975780f9ca",
+    "md5": "4910b756f4e611055140e80f757d9325",
+    "sha256": "30f49b9094bff904a42caeec32515715fe625a56dc48bd7c0e3d9988c0ad4bd7",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "__init__.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/plain",
+    "file_type": "ASCII text"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 47,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/compatibility.py",
+    "size": 1598,
+    "sha1": "9c74e64e9a71903bb227907ea1806eac77e52434",
+    "md5": "5231077fd0628314246fcba7817b561e",
+    "sha256": "3151f66c476208c3154cb6c4fb557a2a253bab82f0ab33fb3c8b9f7976be9e33",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "compatibility.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 48,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/current_thread_executor.py",
+    "size": 2974,
+    "sha1": "aacf7e5e2e5ba78ccfb67fa10e9e6b22c3935c9b",
+    "md5": "b4c45f37055d88dd11b15eb4de51b074",
+    "sha256": "ddd445b778c097fc75c2bf69ad964cbadd3bd6999d1dd2306d39d401855e8e3e",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "current_thread_executor.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 49,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/local.py",
+    "size": 4849,
+    "sha1": "0de5075d1ce4a1a17d70ad6ee523e3d947074899",
+    "md5": "e4103a2fcd6a3f23a036307c978271d7",
+    "sha256": "ee0fcf4a8e6fa9df8a4643bb48e82892d496afce44b6c8b8aea2721755545e1c",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "local.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 50,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/server.py",
+    "size": 5915,
+    "sha1": "ebe97b4c2689537e9387dd8dac353c3e010f8f02",
+    "md5": "5b7619584de19d8f1a00fb5a43349153",
+    "sha256": "885267fee0fea687875a02ceb929ca095312d47aaa57e20e4ce382f397caaf4d",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "server.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 51,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/sync.py",
+    "size": 14081,
+    "sha1": "702381ba6ecb30bbfdcaf0d466a25f470dd9938b",
+    "md5": "44ec43af7ee367c7d6a5808d37133144",
+    "sha256": "fa4651a3b79201a4dc44a4096cd49ec8f427e912ea0ee05c666357b413a8afe7",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "sync.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 52,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/testing.py",
+    "size": 3119,
+    "sha1": "534de2315197b14d0571edc5ed3b3b8ceade0d24",
+    "md5": "aff31de5fa753643adacf0311aa553f4",
+    "sha256": "ddbc8d455eceb68fc583c67e7c4ad0277c867fb39095c51ec5b37f70342e8334",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "testing.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 53,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/timeout.py",
+    "size": 3914,
+    "sha1": "361968f116e8ff9156511bf22f6aa04426f0c540",
+    "md5": "8114ef1d7c1488ebf3a1766dbd39d427",
+    "sha256": "126c3e3a8a75a517d2739612304607804cf5f34da63fa25d03a6f11f7edb6f2f",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [
+      {
+        "key": "apache-2.0",
+        "name": "Apache License 2.0",
+        "owner": "Apache Software Foundation",
+        "score": 100.0,
+        "category": "Permissive",
+        "end_line": 2,
+        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+        "short_name": "Apache 2.0",
+        "start_line": 2,
+        "homepage_url": "http://www.apache.org/licenses/",
+        "is_exception": false,
+        "matched_rule": {
+          "matcher": "2-aho",
+          "licenses": [
+            "apache-2.0"
+          ],
+          "identifier": "apache-2.0_174.RULE",
+          "rule_length": 6,
+          "is_license_tag": false,
+          "match_coverage": 100.0,
+          "matched_length": 6,
+          "rule_relevance": 100.0,
+          "is_license_text": false,
+          "is_license_notice": true,
+          "license_expression": "apache-2.0",
+          "is_license_reference": false
+        },
+        "matched_text": "# under the Apache 2.0 license. You may see the original project at",
+        "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+        "spdx_license_key": "Apache-2.0"
+      }
+    ],
+    "license_expressions": [
+      "apache-2.0"
+    ],
+    "emails": [],
+    "urls": [
+      {
+        "url": "https://github.com/aio-libs/async-timeout",
+        "end_line": 3,
+        "start_line": 3
+      },
+      {
+        "url": "https://github.com/",
+        "end_line": 24,
+        "start_line": 24
+      },
+      {
+        "url": "https://github.com/python/asyncio/issues/392",
+        "end_line": 83,
+        "start_line": 83
+      }
+    ],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "timeout.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 54,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref/wsgi.py",
+    "size": 6575,
+    "sha1": "1f06eb4dd6d38b1a3e2a9b9e751744b303c37e0d",
+    "md5": "4eed1361d0e454149f95fca85c84f33f",
+    "sha256": "f8bd1ea3fb8afddabb10f8efd66796d41446cad51168ef4d3c44b19c973d0ad0",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "wsgi.py",
+    "extension": ".py",
+    "programming_language": "Python",
+    "mime_type": "text/x-script.python",
+    "file_type": "Python script, ASCII text executable"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 55,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info",
+    "size": 0,
+    "sha1": "",
+    "md5": "",
+    "sha256": "",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "directory",
+    "extra_data": {},
+    "name": "asgiref-3.3.0.dist-info",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "",
+    "file_type": ""
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 56,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+    "size": 1552,
+    "sha1": "baf11129ce63c4eef654f39a360b31cfc7d1ac67",
+    "md5": "f09eb47206614a4954c51db8a94840fa",
+    "sha256": "b846415d1b514e9c1dff14a22deb906d794bc546ca6129f950a18cd091e2a669",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [
+      {
+        "value": "Copyright (c) Django Software Foundation and individual contributors",
+        "end_line": 2,
+        "start_line": 1
+      }
+    ],
+    "holders": [
+      {
+        "value": "Django Software Foundation and individual contributors",
+        "end_line": 2,
+        "start_line": 1
+      }
+    ],
+    "authors": [],
+    "licenses": [
+      {
+        "key": "bsd-new",
+        "name": "BSD-3-Clause",
+        "owner": "Regents of the University of California",
+        "score": 100.0,
+        "category": "Permissive",
+        "end_line": 27,
+        "spdx_url": "https://spdx.org/licenses/BSD-3-Clause",
+        "text_url": "http://www.opensource.org/licenses/BSD-3-Clause",
+        "short_name": "BSD-3-Clause",
+        "start_line": 4,
+        "homepage_url": "http://www.opensource.org/licenses/BSD-3-Clause",
+        "is_exception": false,
+        "matched_rule": {
+          "matcher": "2-aho",
+          "licenses": [
+            "bsd-new"
+          ],
+          "identifier": "bsd-new_683.RULE",
+          "rule_length": 214,
+          "is_license_tag": false,
+          "match_coverage": 100.0,
+          "matched_length": 214,
+          "rule_relevance": 100.0,
+          "is_license_text": true,
+          "is_license_notice": false,
+          "license_expression": "bsd-new",
+          "is_license_reference": false
+        },
+        "matched_text": "Redistribution and use in source and binary forms, with or without modification,\nare permitted provided that the following conditions are met:\n\n    1. Redistributions of source code must retain the above copyright notice,\n       this list of conditions and the following disclaimer.\n\n    2. Redistributions in binary form must reproduce the above copyright\n       notice, this list of conditions and the following disclaimer in the\n       documentation and/or other materials provided with the distribution.\n\n    3. Neither the name of Django nor the names of its contributors may be used\n       to endorse or promote products derived from this software without\n       specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR\nANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\n(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\nLOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON\nANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\nSOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+        "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:bsd-new",
+        "spdx_license_key": "BSD-3-Clause"
+      }
+    ],
+    "license_expressions": [
+      "bsd-new"
+    ],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "LICENSE",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "text/plain",
+    "file_type": "ASCII text"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 57,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+    "size": 8800,
+    "sha1": "53d0f6e1cbf6a3c31fb0aa3089b2ca98ad95fc49",
+    "md5": "4b50d67ff7994afcad22c6ef154cf052",
+    "sha256": "70f98f4eb9f6068b192b5464fcdf69e29a8ff09962bfce84bbb052baeee44f33",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [
+      {
+        "value": "Django Software Foundation",
+        "end_line": 9,
+        "start_line": 6
+      }
+    ],
+    "licenses": [
+      {
+        "key": "bsd-new",
+        "name": "BSD-3-Clause",
+        "owner": "Regents of the University of California",
+        "score": 95.0,
+        "category": "Permissive",
+        "end_line": 8,
+        "spdx_url": "https://spdx.org/licenses/BSD-3-Clause",
+        "text_url": "http://www.opensource.org/licenses/BSD-3-Clause",
+        "short_name": "BSD-3-Clause",
+        "start_line": 8,
+        "homepage_url": "http://www.opensource.org/licenses/BSD-3-Clause",
+        "is_exception": false,
+        "matched_rule": {
+          "matcher": "2-aho",
+          "licenses": [
+            "bsd-new"
+          ],
+          "identifier": "bsd-new_89.RULE",
+          "rule_length": 2,
+          "is_license_tag": false,
+          "match_coverage": 100.0,
+          "matched_length": 2,
+          "rule_relevance": 95.0,
+          "is_license_text": false,
+          "is_license_notice": false,
+          "license_expression": "bsd-new",
+          "is_license_reference": true
+        },
+        "matched_text": "License: BSD",
+        "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:bsd-new",
+        "spdx_license_key": "BSD-3-Clause"
+      },
+      {
+        "key": "bsd-new",
+        "name": "BSD-3-Clause",
+        "owner": "Regents of the University of California",
+        "score": 99.0,
+        "category": "Permissive",
+        "end_line": 16,
+        "spdx_url": "https://spdx.org/licenses/BSD-3-Clause",
+        "text_url": "http://www.opensource.org/licenses/BSD-3-Clause",
+        "short_name": "BSD-3-Clause",
+        "start_line": 16,
+        "homepage_url": "http://www.opensource.org/licenses/BSD-3-Clause",
+        "is_exception": false,
+        "matched_rule": {
+          "matcher": "2-aho",
+          "licenses": [
+            "bsd-new"
+          ],
+          "identifier": "pypi_bsd_license.RULE",
+          "rule_length": 5,
+          "is_license_tag": true,
+          "match_coverage": 100.0,
+          "matched_length": 5,
+          "rule_relevance": 99.0,
+          "is_license_text": false,
+          "is_license_notice": false,
+          "license_expression": "bsd-new",
+          "is_license_reference": false
+        },
+        "matched_text": "Classifier: License :: OSI Approved :: BSD License",
+        "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:bsd-new",
+        "spdx_license_key": "BSD-3-Clause"
+      }
+    ],
+    "license_expressions": [
+      "bsd-new",
+      "bsd-new"
+    ],
+    "emails": [
+      {
+        "email": "foundation@djangoproject.com",
+        "end_line": 7,
+        "start_line": 7
+      },
+      {
+        "email": "security@djangoproject.com",
+        "end_line": 224,
+        "start_line": 224
+      }
+    ],
+    "urls": [
+      {
+        "url": "https://github.com/django/asgiref/",
+        "end_line": 5,
+        "start_line": 5
+      },
+      {
+        "url": "https://asgi.readthedocs.io/",
+        "end_line": 9,
+        "start_line": 9
+      },
+      {
+        "url": "https://docs.djangoproject.com/en/stable/topics/async/#async-adapter-functions",
+        "end_line": 10,
+        "start_line": 10
+      },
+      {
+        "url": "https://github.com/django/asgiref/blob/master/CHANGELOG.txt",
+        "end_line": 11,
+        "start_line": 11
+      },
+      {
+        "url": "https://api.travis-ci.org/django/asgiref.svg",
+        "end_line": 34,
+        "start_line": 34
+      },
+      {
+        "url": "https://travis-ci.org/django/asgiref",
+        "end_line": 35,
+        "start_line": 35
+      },
+      {
+        "url": "https://img.shields.io/pypi/v/asgiref.svg",
+        "end_line": 37,
+        "start_line": 37
+      },
+      {
+        "url": "https://pypi.python.org/pypi/asgiref",
+        "end_line": 38,
+        "start_line": 38
+      },
+      {
+        "url": "https://asgi.readthedocs.io/en/latest/",
+        "end_line": 42,
+        "start_line": 42
+      },
+      {
+        "url": "https://github.com/andrewgodwin/frequensgi",
+        "end_line": 107,
+        "start_line": 107
+      },
+      {
+        "url": "https://github.com/django/channels/blob/master/CONTRIBUTING.rst",
+        "end_line": 136,
+        "start_line": 136
+      },
+      {
+        "url": "http://www.sphinx-doc.org/",
+        "end_line": 152,
+        "start_line": 152
+      },
+      {
+        "url": "https://docs.djangoproject.com/en/dev/internals/security",
+        "end_line": 226,
+        "start_line": 226
+      },
+      {
+        "url": "https://github.com/django/channels/blob/master/README.rst",
+        "end_line": 231,
+        "start_line": 231
+      }
+    ],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "METADATA",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "text/plain",
+    "file_type": "ASCII text"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 58,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+    "size": 1073,
+    "sha1": "5854ecf1ad649848d7cda8096d09ac258c888208",
+    "md5": "38e56802a5adcafeae35efc6e3d218ba",
+    "sha256": "2c1983592aa38f0bfb0afacc73ddc5b46ce10e8e89ceaa9fed1e5fc6361b608d",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "RECORD",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "application/csv",
+    "file_type": "CSV text"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 59,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+    "size": 8,
+    "sha1": "612390bd0d0227c009f9c99b479878adf7ac2f23",
+    "md5": "680e61db4d95c8d9501b7a49fa2bf0b2",
+    "sha256": "6e89108c2cf0c0446174188f76f60465ae1c1f14f83427807df40d52a27cb2c8",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "top_level.txt",
+    "extension": ".txt",
+    "programming_language": "",
+    "mime_type": "text/plain",
+    "file_type": "ASCII text"
+  }
+},
+{
+  "model": "scanpipe.codebaseresource",
+  "pk": 60,
+  "fields": {
+    "path": "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+    "size": 92,
+    "sha1": "ddd91bc89b15fc5c66e0fa259392955c74ba041f",
+    "md5": "5ccc7519eb42f1dfceee6e7d685f1ff5",
+    "sha256": "11546323af45e6a5639bf620a9c4d73e74c0bf705f494af4595007b923f75e8a",
+    "sha512": "",
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "licenses": [],
+    "license_expressions": [],
+    "emails": [],
+    "urls": [],
+    "rootfs_path": "",
+    "status": "",
+    "type": "file",
+    "extra_data": {},
+    "name": "WHEEL",
+    "extension": "",
+    "programming_language": "",
+    "mime_type": "text/plain",
+    "file_type": "ASCII text"
+  }
+},
+{
+  "model": "scanpipe.discoveredpackage",
+  "pk": 4,
+  "fields": {
+    "type": "pypi",
+    "namespace": "",
+    "name": "asgiref",
+    "version": "3.3.0",
+    "qualifiers": "",
+    "subpath": "",
+    "uuid": "6e89bd3c-1885-4fc3-8ca0-4f7c42272709",
+    "last_modified_date": null,
+    "filename": "",
+    "primary_language": "Python",
+    "description": "asgiref\n=======\n\n.. image:: https://api.travis-ci.org/django/asgiref.svg\n    :target: https://travis-ci.org/django/asgiref\n\n.. image:: https://img.shields.io/pypi/v/asgiref.svg\n    :target: https://pypi.python.org/pypi/asgiref\n\nASGI is a standard for Python asynchronous web apps and servers to communicate\nwith each other, and positioned as an asynchronous successor to WSGI. You can\nread more at https://asgi.readthedocs.io/en/latest/\n\nThis package includes ASGI base libraries, such as:\n\n* Sync-to-async and async-to-sync function wrappers, ``asgiref.sync``\n* Server base classes, ``asgiref.server``\n* A WSGI-to-ASGI adapter, in ``asgiref.wsgi``\n\n\nFunction wrappers\n-----------------\n\nThese allow you to wrap or decorate async or sync functions to call them from\nthe other style (so you can call async functions from a synchronous thread,\nor vice-versa).\n\nIn particular:\n\n* AsyncToSync lets a synchronous subthread stop and wait while the async\n  function is called on the main thread's event loop, and then control is\n  returned to the thread when the async function is finished.\n\n* SyncToAsync lets async code call a synchronous function, which is run in\n  a threadpool and control returned to the async coroutine when the synchronous\n  function completes.\n\nThe idea is to make it easier to call synchronous APIs from async code and\nasynchronous APIs from synchronous code so it's easier to transition code from\none style to the other. In the case of Channels, we wrap the (synchronous)\nDjango view system with SyncToAsync to allow it to run inside the (asynchronous)\nASGI server.\n\nNote that exactly what threads things run in is very specific, and aimed to\nkeep maximum compatibility with old synchronous code. See\n\"Synchronous code & Threads\" below for a full explanation. By default,\n``sync_to_async`` will run all synchronous code in the program in the same\nthread for safety reasons; you can disable this for more performance with\n``@sync_to_async(thread_sensitive=False)``, but make sure that your code does\nnot rely on anything bound to threads (like database connections) when you do.\n\n\nThreadlocal replacement\n-----------------------\n\nThis is a drop-in replacement for ``threading.local`` that works with both\nthreads and asyncio Tasks. Even better, it will proxy values through from a\ntask-local context to a thread-local context when you use ``sync_to_async``\nto run things in a threadpool, and vice-versa for ``async_to_sync``.\n\nIf you instead want true thread- and task-safety, you can set\n``thread_critical`` on the Local object to ensure this instead.\n\n\nServer base classes\n-------------------\n\nIncludes a ``StatelessServer`` class which provides all the hard work of\nwriting a stateless server (as in, does not handle direct incoming sockets\nbut instead consumes external streams or sockets to work out what is happening).\n\nAn example of such a server would be a chatbot server that connects out to\na central chat server and provides a \"connection scope\" per user chatting to\nit. There's only one actual connection, but the server has to separate things\ninto several scopes for easier writing of the code.\n\nYou can see an example of this being used in `frequensgi <https://github.com/andrewgodwin/frequensgi>`_.\n\n\nWSGI-to-ASGI adapter\n--------------------\n\nAllows you to wrap a WSGI application so it appears as a valid ASGI application.\n\nSimply wrap it around your WSGI application like so::\n\n    asgi_application = WsgiToAsgi(wsgi_application)\n\nThe WSGI application will be run in a synchronous threadpool, and the wrapped\nASGI application will be one that accepts ``http`` class messages.\n\nPlease note that not all extended features of WSGI may be supported (such as\nfile handles for incoming POST bodies).\n\n\nDependencies\n------------\n\n``asgiref`` requires Python 3.5 or higher.\n\n\nContributing\n------------\n\nPlease refer to the\n`main Channels contributing docs <https://github.com/django/channels/blob/master/CONTRIBUTING.rst>`_.\n\n\nTesting\n'''''''\n\nTo run tests, make sure you have installed the ``tests`` extra with the package::\n\n    cd asgiref/\n    pip install -e .[tests]\n    pytest\n\n\nBuilding the documentation\n''''''''''''''''''''''''''\n\nThe documentation uses `Sphinx <http://www.sphinx-doc.org>`_::\n\n    cd asgiref/docs/\n    pip install sphinx\n\nTo build the docs, you can use the default tools::\n\n    sphinx-build -b html . _build/html  # or `make html`, if you've got make set up\n    cd _build/html\n    python -m http.server\n\n...or you can use ``sphinx-autobuild`` to run a server and rebuild/reload\nyour documentation changes automatically::\n\n    pip install sphinx-autobuild\n    sphinx-autobuild . _build/html\n\n\nImplementation Details\n----------------------\n\nSynchronous code & threads\n''''''''''''''''''''''''''\n\nThe ``asgiref.sync`` module provides two wrappers that let you go between\nasynchronous and synchronous code at will, while taking care of the rough edges\nfor you.\n\nUnfortunately, the rough edges are numerous, and the code has to work especially\nhard to keep things in the same thread as much as possible. Notably, the\nrestrictions we are working with are:\n\n* All synchronous code called through ``SyncToAsync`` and marked with\n  ``thread_sensitive`` should run in the same thread as each other (and if the\n  outer layer of the program is synchronous, the main thread)\n\n* If a thread already has a running async loop, ``AsyncToSync`` can't run things\n  on that loop if it's blocked on synchronous code that is above you in the\n  call stack.\n\nThe first compromise you get to might be that ``thread_sensitive`` code should\njust run in the same thread and not spawn in a sub-thread, fulfilling the first\nrestriction, but that immediately runs you into the second restriction.\n\nThe only real solution is to essentially have a variant of ThreadPoolExecutor\nthat executes any ``thread_sensitive`` code on the outermost synchronous\nthread - either the main thread, or a single spawned subthread.\n\nThis means you now have two basic states:\n\n* If the outermost layer of your program is synchronous, then all async code\n  run through ``AsyncToSync`` will run in a per-call event loop in arbitary\n  sub-threads, while all ``thread_sensitive`` code will run in the main thread.\n\n* If the outermost layer of your program is asynchronous, then all async code\n  runs on the main thread's event loop, and all ``thread_sensitive`` synchronous\n  code will run in a single shared sub-thread.\n\nCruicially, this means that in both cases there is a thread which is a shared\nresource that all ``thread_sensitive`` code must run on, and there is a chance\nthat this thread is currently blocked on its own ``AsyncToSync`` call. Thus,\n``AsyncToSync`` needs to act as an executor for thread code while it's blocking.\n\nThe ``CurrentThreadExecutor`` class provides this functionality; rather than\nsimply waiting on a Future, you can call its ``run_until_future`` method and\nit will run submitted code until that Future is done. This means that code\ninside the call can then run code on your thread.\n\n\nMaintenance and Security\n------------------------\n\nTo report security issues, please contact security@djangoproject.com. For GPG\nsignatures and more security process information, see\nhttps://docs.djangoproject.com/en/dev/internals/security/.\n\nTo report bugs or request new features, please open a new GitHub issue.\n\nThis repository is part of the Channels project. For the shepherd and maintenance team, please see the\n`main Channels readme <https://github.com/django/channels/blob/master/README.rst>`_.\n\n\n",
+    "release_date": null,
+    "homepage_url": "https://github.com/django/asgiref/",
+    "download_url": "",
+    "size": null,
+    "sha1": "",
+    "md5": "",
+    "bug_tracking_url": "",
+    "code_view_url": "",
+    "vcs_url": "",
+    "copyright": "",
+    "license_expression": "unknown AND bsd-new",
+    "declared_license": "OrderedDict([('license', 'BSD'), ('classifiers', ['License :: OSI Approved :: BSD License'])])",
+    "notice_text": "",
+    "manifest_path": "",
+    "contains_source_code": null,
+    "project": "44915ce7-7664-42ff-8334-04399f844c04",
+    "missing_resources": [],
+    "modified_resources": [],
+    "keywords": [
+      "Development Status :: 5 - Production/Stable",
+      "Environment :: Web Environment",
+      "Intended Audience :: Developers",
+      "Operating System :: OS Independent",
+      "Programming Language :: Python",
+      "Programming Language :: Python :: 3",
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.5",
+      "Programming Language :: Python :: 3.6",
+      "Programming Language :: Python :: 3.7",
+      "Programming Language :: Python :: 3.8",
+      "Topic :: Internet :: WWW/HTTP"
+    ],
+    "source_packages": [],
+    "codebase_resources": [
+      43
+    ]
+  }
+}
+]

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -881,11 +881,15 @@ class ScanPipeModelsTest(TestCase):
         topdown_paths = list(r.path for r in asgiref_root.walk(topdown=True))
         # We walk from the root Resource of `asgiref_vc` to make it comparable
         # to how we are walking the children of `asgiref_root`
-        expected_topdown_paths = list(r.path for r in asgiref_vc_root.walk(asgiref_vc, topdown=True))
+        expected_topdown_paths = list(
+            r.path for r in asgiref_vc_root.walk(asgiref_vc, topdown=True)
+        )
         self.assertEqual(expected_topdown_paths, topdown_paths)
 
         bottom_up_paths = list(r.path for r in asgiref_root.walk(topdown=False))
-        expected_bottom_up_paths = list(r.path for r in asgiref_vc_root.walk(asgiref_vc, topdown=False))
+        expected_bottom_up_paths = list(
+            r.path for r in asgiref_vc_root.walk(asgiref_vc, topdown=False)
+        )
         self.assertEqual(expected_bottom_up_paths, bottom_up_paths)
 
     def test_scanpipe_codebase_resource_create_and_add_package(self):

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -36,8 +36,6 @@ from django.test import TestCase
 from django.test import TransactionTestCase
 from django.utils import timezone
 
-from commoncode.resource import VirtualCodebase
-
 from scanpipe.models import CodebaseResource
 from scanpipe.models import DiscoveredPackage
 from scanpipe.models import Project
@@ -874,22 +872,51 @@ class ScanPipeModelsTest(TestCase):
 
     def test_scanpipe_codebase_resource_walk(self):
         asgiref_root = self.project_asgiref.codebaseresources.get(path="codebase")
-        asgiref_scan = self.data_location / "asgiref-3.3.0_scan.json"
-        asgiref_vc = VirtualCodebase(location=asgiref_scan)
-        asgiref_vc_root = asgiref_vc.root
 
         topdown_paths = list(r.path for r in asgiref_root.walk(topdown=True))
-        # We walk from the root Resource of `asgiref_vc` to make it comparable
-        # to how we are walking the children of `asgiref_root`
-        expected_topdown_paths = list(
-            r.path for r in asgiref_vc_root.walk(asgiref_vc, topdown=True)
-        )
+        expected_topdown_paths = [
+            "codebase/asgiref-3.3.0-py3-none-any.whl",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+        ]
         self.assertEqual(expected_topdown_paths, topdown_paths)
 
         bottom_up_paths = list(r.path for r in asgiref_root.walk(topdown=False))
-        expected_bottom_up_paths = list(
-            r.path for r in asgiref_vc_root.walk(asgiref_vc, topdown=False)
-        )
+        expected_bottom_up_paths = [
+            "codebase/asgiref-3.3.0-py3-none-any.whl",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
+        ]
         self.assertEqual(expected_bottom_up_paths, bottom_up_paths)
 
     def test_scanpipe_codebase_resource_create_and_add_package(self):

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -52,10 +52,7 @@ from scanpipe.tests.pipelines.do_nothing import DoNothing
 scanpipe_app = apps.get_app_config("scanpipe")
 
 
-class ScanPipeModelsTest(TestCase):
-    data_location = Path(__file__).parent / "data"
-    fixtures = [data_location / "asgiref-3.3.0_fixtures.json"]
-
+class BaseScanPipeModelsTest:
     def setUp(self):
         self.project1 = Project.objects.create(name="Analysis")
         self.project_asgiref = Project.objects.get(name="asgiref")
@@ -66,6 +63,11 @@ class ScanPipeModelsTest(TestCase):
             pipeline_name="pipeline",
             **kwargs,
         )
+
+
+class ScanPipeModelsTest(BaseScanPipeModelsTest, TestCase):
+    data_location = Path(__file__).parent / "data"
+    fixtures = [data_location / "asgiref-3.3.0_fixtures.json"]
 
     def test_scanpipe_project_model_extra_data(self):
         self.assertEqual({}, self.project1.extra_data)
@@ -870,55 +872,6 @@ class ScanPipeModelsTest(TestCase):
         ]
         self.assertEqual(expected, [resource.path for resource in children])
 
-    def test_scanpipe_codebase_resource_walk(self):
-        asgiref_root = self.project_asgiref.codebaseresources.get(path="codebase")
-
-        topdown_paths = list(r.path for r in asgiref_root.walk(topdown=True))
-        expected_topdown_paths = [
-            "codebase/asgiref-3.3.0-py3-none-any.whl",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
-        ]
-        self.assertEqual(expected_topdown_paths, topdown_paths)
-
-        bottom_up_paths = list(r.path for r in asgiref_root.walk(topdown=False))
-        expected_bottom_up_paths = [
-            "codebase/asgiref-3.3.0-py3-none-any.whl",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
-        ]
-        self.assertEqual(expected_bottom_up_paths, bottom_up_paths)
-
     def test_scanpipe_codebase_resource_create_and_add_package(self):
         codebase_resource = CodebaseResource.objects.create(
             project=self.project1, path="filename.ext"
@@ -1069,3 +1022,60 @@ class ScanPipeModelsTransactionTest(TransactionTestCase):
         self.assertEqual(expected_message, error.message)
         self.assertEqual(bad_data["version"], error.details["version"])
         self.assertIn("in save", error.traceback)
+
+
+class ScanPipeWalkTest(BaseScanPipeModelsTest, TestCase):
+    data_location = Path(__file__).parent / "data"
+    fixtures = [data_location / "asgiref-3.3.0_walk_test_fixtures.json"]
+
+    def test_scanpipe_codebase_resource_walk(self):
+        fixtures = [self.data_location / "asgiref-3.3.0_walk_test_fixtures.json"]
+        project = Project.objects.create(name="asgiref_walk_test")
+        project_asgiref = Project.objects.get(name="asgiref")
+        asgiref_root = self.project_asgiref.codebaseresources.get(path="codebase")
+
+        topdown_paths = list(r.path for r in asgiref_root.walk(topdown=True))
+        expected_topdown_paths = [
+            "codebase/asgiref-3.3.0.whl",
+            "codebase/asgiref-3.3.0.whl-extract",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+        ]
+        self.assertEqual(expected_topdown_paths, topdown_paths)
+
+        bottom_up_paths = list(r.path for r in asgiref_root.walk(topdown=False))
+        expected_bottom_up_paths = [
+            "codebase/asgiref-3.3.0.whl",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0.whl-extract",
+        ]
+        self.assertEqual(expected_bottom_up_paths, bottom_up_paths)

--- a/scanpipe/tests/test_pipes.py
+++ b/scanpipe/tests/test_pipes.py
@@ -31,7 +31,6 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.test import TransactionTestCase
 
-from commoncode.resource import VirtualCodebase
 from scancode.interrupt import TimeoutError as InterruptTimeoutError
 
 from scanpipe.models import CodebaseResource
@@ -539,15 +538,53 @@ class ScanPipePipesTest(TestCase):
 
         project = Project.objects.get(name="asgiref")
         project_codebase = codebase.ProjectCodebase(project)
-        asgiref_scan = self.data_location / "asgiref-3.3.0_scan.json"
-        asgiref_vc = VirtualCodebase(location=asgiref_scan)
 
         topdown_paths = list(r.path for r in project_codebase.walk(topdown=True))
-        expected_topdown_paths = list(r.path for r in asgiref_vc.walk(topdown=True))
+        expected_topdown_paths = [
+            "codebase",
+            "codebase/asgiref-3.3.0-py3-none-any.whl",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+        ]
         self.assertEqual(expected_topdown_paths, topdown_paths)
 
         bottom_up_paths = list(r.path for r in project_codebase.walk(topdown=False))
-        expected_bottom_up_paths = list(r.path for r in asgiref_vc.walk(topdown=False))
+        expected_bottom_up_paths = [
+            "codebase/asgiref-3.3.0-py3-none-any.whl",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
+            "codebase",
+        ]
         self.assertEqual(expected_bottom_up_paths, bottom_up_paths)
 
     @mock.patch("requests.get")

--- a/scanpipe/tests/test_pipes.py
+++ b/scanpipe/tests/test_pipes.py
@@ -503,7 +503,8 @@ class ScanPipePipesTest(TestCase):
             project_codebase.root
 
         self.assertEqual([], list(project_codebase.resources))
-        self.assertEqual([], list(project_codebase.walk()))
+        with self.assertRaises(AttributeError):
+            list(project_codebase.walk())
         with self.assertRaises(AttributeError):
             project_codebase.get_tree()
 

--- a/scanpipe/tests/test_pipes.py
+++ b/scanpipe/tests/test_pipes.py
@@ -533,7 +533,7 @@ class ScanPipePipesTest(TestCase):
         self.assertEqual(expected, tree)
 
     def test_scanpipe_pipes_codebase_project_codebase_class_walk(self):
-        fixtures = self.data_location / "asgiref-3.3.0_fixtures.json"
+        fixtures = self.data_location / "asgiref-3.3.0_walk_test_fixtures.json"
         call_command("loaddata", fixtures, **{"verbosity": 0})
 
         project = Project.objects.get(name="asgiref")
@@ -542,47 +542,47 @@ class ScanPipePipesTest(TestCase):
         topdown_paths = list(r.path for r in project_codebase.walk(topdown=True))
         expected_topdown_paths = [
             "codebase",
-            "codebase/asgiref-3.3.0-py3-none-any.whl",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+            "codebase/asgiref-3.3.0.whl",
+            "codebase/asgiref-3.3.0.whl-extract",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
         ]
         self.assertEqual(expected_topdown_paths, topdown_paths)
 
         bottom_up_paths = list(r.path for r in project_codebase.walk(topdown=False))
         expected_bottom_up_paths = [
-            "codebase/asgiref-3.3.0-py3-none-any.whl",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/compatibility.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/current_thread_executor.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/__init__.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/local.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/server.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/sync.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/testing.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/timeout.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref/wsgi.py",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/METADATA",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/RECORD",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract/asgiref-3.3.0.dist-info",
-            "codebase/asgiref-3.3.0-py3-none-any.whl-extract",
+            "codebase/asgiref-3.3.0.whl",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/compatibility.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/current_thread_executor.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/__init__.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/local.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/server.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/sync.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/testing.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/timeout.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref/wsgi.py",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/LICENSE",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/METADATA",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/RECORD",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/top_level.txt",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info/WHEEL",
+            "codebase/asgiref-3.3.0.whl-extract/asgiref-3.3.0.dist-info",
+            "codebase/asgiref-3.3.0.whl-extract",
             "codebase",
         ]
         self.assertEqual(expected_bottom_up_paths, bottom_up_paths)


### PR DESCRIPTION
The walk method has been added to `CodebaseResource` and `ProjectCodebase` models to mimic the walk method on `commoncode.resource.Resource` and `commoncode.resource.Codebase` classes, respectively. 

`CodebaseResource.walk()` has the argument `topdown`. if `topdown` is True, we start visiting the children of a Resource from the Resource we are currently at. If `topdown` is False, then we start visiting the bottom-most child Resource of the Resource we are currently at. 

Likewise, `ProjectCodebase.walk()` also has the argument `topdown`, which has similar behavior where `topdown` value of True means we start visiting the Resources of a ProjectCodebase from the root CodebaseResource down. A `topdown` value of False means we start visiting the bottom-most Resources of a `ProjectCodebase` up.

Signed-off-by: Jono Yang <jyang@nexb.com>