### PR TITLE
Fix log to show time in local timezone #142

### DIFF
--- a/scanpipe/pipelines/__init__.py
+++ b/scanpipe/pipelines/__init__.py
@@ -79,7 +79,8 @@ class Pipeline:
         """
         Log the `message` to this module logger and to the Run instance.
         """
-        timestamp = timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-4]
+        time = timezone.now().astimezone(timezone.get_current_timezone())
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-4]
         message = f"{timestamp} {message}"
         logger.info(message)
         self.run.append_to_log(message, save=True)


### PR DESCRIPTION
Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>

```
2021-04-28 20:57:23.42 Step [scan_for_files] completed in 3670.36 seconds
2021-04-28 20:57:23.42 Step [analyze_scanned_files] starting
2021-04-28 20:57:31.67 Step [analyze_scanned_files] completed in 8.25 seconds
2021-04-28 20:57:31.68 Step [tag_not_analyzed_codebase_resources] starting
2021-04-28 20:57:31.74 Step [tag_not_analyzed_codebase_resources] completed in 0.06 seconds
2021-04-28 20:57:31.75 Pipeline completed
[29/Apr/2021 04:25:27] "GET /project/f534fce6-8504-4362-b322-f30c67dcb70e/ HTTP/1.1" 200 32418
[29/Apr/2021 04:25:28] "GET /static/fontawesome-5.15.1.all.min.js HTTP/1.1" 304 0
[29/Apr/2021 04:25:28] "GET /static/highlight-10.6.0.min.js HTTP/1.1" 304 0
[29/Apr/2021 04:25:28] "GET /static/billboard-3.0.1.pkgd.min.js HTTP/1.1" 304 0
[29/Apr/2021 04:39:13] "GET /project/f534fce6-8504-4362-b322-f30c67dcb70e/errors/ HTTP/1.1" 200 10584
```

The log wasn't showing the current timezone, only the page was. This fixes it. Now it shows the same time both in local timezones.


```
2021-04-29 15:28:04.86 Step [build_inventory_from_scan] starting
2021-04-29 15:28:04.90 Step [build_inventory_from_scan] completed in 0.04 seconds
2021-04-29 15:28:04.90 Step [csv_output] starting
2021-04-29 15:28:04.96 Step [csv_output] completed in 0.05 seconds
2021-04-29 15:28:04.96 Pipeline completed
[29/Apr/2021 15:28:04] "POST /project/246bd5e3-557a-49b1-af77-b708da4dee75/ HTTP/1.1" 302 0
[29/Apr/2021 15:28:05] "GET /project/246bd5e3-557a-49b1-af77-b708da4dee75/ HTTP/1.1" 200 23642
[29/Apr/2021 15:28:14] "GET /project/ HTTP/1.1" 200 7767
[29/Apr/2021 15:28:17]
```