### PR TITLE
Improve XLSX creation #206

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 // Release notes
 // -------------
 
+### unreleased
+
+- Improve XLSX creation. We now check that the content is correctly added before
+  calling XlsxWriter and report and error if the truncated can be truncated.
+  https://github.com/nexB/scancode.io/issues/206
+
 ### v21.6.10
 
 - Add support for VM image formats extraction such as VMDK, VDI and QCOW.

--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -236,9 +236,13 @@ def _add_xlsx_worksheet(workbook, worksheet_name, rows, fields):
     """
     worksheet = workbook.add_worksheet(worksheet_name)
     worksheet.set_default_row(height=14)
-    worksheet.write_row(row=0, col=0, data=list(fields) + ["xlsx_errors"])
+
+    header = list(fields) + ["xlsx_errors"]
+    worksheet.write_row(row=0, col=0, data=header)
 
     errors_count = 0
+    errors_col_index = len(fields) - 1  # rows and cols are zero-indexed
+
     for row_index, record in enumerate(rows, start=1):
         row_errors = []
         for col_index, field in enumerate(fields):
@@ -258,7 +262,7 @@ def _add_xlsx_worksheet(workbook, worksheet_name, rows, fields):
         if row_errors:
             errors_count += len(row_errors)
             row_errors = "\n".join(row_errors)
-            worksheet.write_string(row_index, col_index + 1, row_errors)
+            worksheet.write_string(row_index, errors_col_index, row_errors)
 
     return errors_count
 

--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -26,6 +26,7 @@ import json
 from django.apps import apps
 from django.core.serializers.json import DjangoJSONEncoder
 
+import saneyaml
 import xlsxwriter
 from license_expression import ordered_unique
 from packagedcode.utils import combine_expressions
@@ -197,45 +198,162 @@ def to_json(project):
     return output_file
 
 
-def _queryset_to_xlsx_worksheet(queryset, workbook, exclude_fields=None):
-    from scanpipe.api.serializers import get_serializer_fields
+def _queryset_to_xlsx_worksheet(queryset, workbook, exclude_fields=()):
+    """
+    Add a new worksheet to the ``workbook`` ``xlsxwriter.Workbook`` using the
+    ``queryset``. The ``queryset`` "model_name" is use as aname for the
+    "worksheet".
+    Exclude fields listed in the ``exclude_fields`` sequence of field names.
 
-    multivalues_separator = "\n"
+    Add an extra trailing "xlsx_errors" column with conversion error messages if
+    any. Return a number of conversion errors.
+    """
+
+    from scanpipe.api.serializers import get_serializer_fields
 
     model_class = queryset.model
     model_name = model_class._meta.model_name
 
-    fieldnames = get_serializer_fields(model_class)
+    fields = get_serializer_fields(model_class)
     exclude_fields = exclude_fields or []
-    fieldnames = [field for field in fieldnames if field not in exclude_fields]
+    fields = [field for field in fields if field not in exclude_fields]
 
-    worksheet = workbook.add_worksheet(model_name)
-    worksheet.write_row(row=0, col=0, data=fieldnames)
+    return _add_xlsx_worksheet(
+        workbook=workbook,
+        worksheet_name=model_name,
+        rows=queryset,
+        fields=fields,
+    )
 
-    for row_index, record in enumerate(queryset.iterator(), start=1):
-        for col_index, field in enumerate(fieldnames):
+
+def _add_xlsx_worksheet(workbook, worksheet_name, rows, fields):
+    """
+    Add a new ``worksheet_name`` worksheet to the ``workbook``
+    ``xlsxwriter.Workbook``. Write the iterable of ``rows`` objects using their
+    attributes listed in the ``fields`` sequence of field names.
+    Add an "xlsx_errors" column with conversion error messages if any.
+    Return a number of conversion errors.
+    """
+    worksheet = workbook.add_worksheet(worksheet_name)
+
+    worksheet.write_row(row=0, col=0, data=list(fields) + ["xlsx_errors"])
+
+    errors_count = 0
+    for row_index, record in enumerate(rows, start=1):
+        row_errors = []
+        for col_index, field in enumerate(fields):
             value = getattr(record, field)
+
             if not value:
                 continue
-            elif field == "license_expressions":
-                value = combine_expressions(value)
-            elif isinstance(value, list):
-                value = [
-                    list(entry.values())[0] if isinstance(entry, dict) else str(entry)
-                    for entry in value
-                ]
-                value = multivalues_separator.join(ordered_unique(value))
-            elif isinstance(value, dict):
-                value = json.dumps(value) if value else ""
 
-            worksheet.write_string(row_index, col_index, str(value))
+            value, error = _adapt_value_for_xlsx(field, value)
+
+            if error:
+                row_errors.append(error)
+
+            if value:
+                worksheet.write_string(row_index, col_index, str(value))
+
+        if row_errors:
+            errors_count += len(row_errors)
+            row_errors = "\n".join(row_errors)
+            worksheet.write_string(row_index, col_index + 1, row_errors)
+
+    return errors_count
+
+
+# Some scan attributes such as "copyrights" are list of dicts.
+#
+#  'authors': [{'end_line': 7, 'start_line': 7, 'value': 'John Doe'}],
+#  'copyrights': [{'end_line': 5, 'start_line': 5, 'value': 'Copyright (c) nexB Inc.'}],
+#  'emails': [{'email': 'joe@foobar.com', 'end_line': 1, 'start_line': 1}],
+#  'holders': [{'end_line': 5, 'start_line': 5, 'value': 'nexB Inc.'}],
+#  'urls': [{'end_line': 3, 'start_line': 3, 'url': 'https://foobar.com/'}]
+#
+# We therefore use a mapping to find which key to use in these mappings until
+# this is fixed updated in scancode-toolkit with these:
+# https://github.com/nexB/scancode-toolkit/pull/2381
+# https://github.com/nexB/scancode-toolkit/issues/2350
+mappings_key_by_fieldname = {
+    "copyrights": "value",
+    "holders": "value",
+    "authors": "value",
+    "emails": "email",
+    "urls": "url",
+}
+
+
+def _adapt_value_for_xlsx(fieldname, value, maximum_length=32767, _adapt=True):
+    """
+    Return a two tuple of:
+    (``value`` adapted for use in an XLSX cell, error message or None)
+
+    Convert the value to a string and performa these adaptations:
+    - Keep only unique values in lists, preserving ordering.
+    - Truncate the "description" field to the first five lines.
+    - Truncate any fieldtoo long to fit in an XLSX cell and report error.
+    - Create a combined license expression for expressions
+    - Normalize line endings
+    - Truncating the value to a ``maximum_length`` supported by XLSX.
+
+    Do nothing if "_adapt" is False (used for tests).
+    """
+    error = None
+    if not _adapt:
+        return value, error
+
+    if not value:
+        return "", error
+
+    if fieldname == "description":
+        max_description_lines = 5
+        value = "\n".join(value.splitlines(False)[:max_description_lines])
+
+    if fieldname == "license_expressions":
+        value = combine_expressions(value)
+
+    # we only get this key in each dict of a list for some fields
+    mapping_key = mappings_key_by_fieldname.get(fieldname)
+    if mapping_key:
+        value = [mapping[mapping_key] for mapping in value]
+
+    # convert these to text lines, remove duplicates
+    if isinstance(value, (list, tuple)):
+        value = (str(v) for v in value if v)
+        value = ordered_unique(value)
+        value = "\n".join(value)
+
+    # convert these to YAML which is the most readable dump format
+    if isinstance(value, dict):
+        value = saneyaml.dump(value)
+
+    value = str(value)
+
+    # XLSX does not like CRLF
+    value = value.replace("\r\n", "\n")
+
+    # XLSX does not like long values
+    len_val = len(value)
+    if len_val > maximum_length:
+        error = (
+            f"The value of: {fieldname} has been truncated from: {len_val} "
+            f"to {maximum_length} length to fit in an XLSL cell maximum length"
+        )
+        value = value[:maximum_length]
+
+    return value, error
 
 
 def to_xlsx(project):
     """
-    Generate results output for the provided `project` as XLSX format.
-    The output file is created in the `project` output/ directory.
+    Generate results output for the provided ``project`` as XLSX format.
+    The output file is created in the ``project`` "output/" directory.
     Return the path of the generated output file.
+
+    Note that the XLSX worksheets contain each an extra "xlxs_errors" column
+    with possible error messages for a row when converting the data to XLSX
+    exceed the limits of what can be stored in a cell.
     """
     output_file = project.get_output_file_path("results", "xlsx")
     exclude_fields = ["licenses", "extra_data", "declared_license"]

--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -212,7 +212,7 @@ def _queryset_to_xlsx_worksheet(queryset, workbook, exclude_fields=()):
     from scanpipe.api.serializers import get_serializer_fields
 
     model_class = queryset.model
-    model_name = model_class._meta.model_name
+    model_name = model_class._meta.verbose_name_plural.title()
 
     fields = get_serializer_fields(model_class)
     exclude_fields = exclude_fields or []
@@ -235,7 +235,7 @@ def _add_xlsx_worksheet(workbook, worksheet_name, rows, fields):
     Return a number of conversion errors.
     """
     worksheet = workbook.add_worksheet(worksheet_name)
-
+    worksheet.set_default_row(height=14)
     worksheet.write_row(row=0, col=0, data=list(fields) + ["xlsx_errors"])
 
     errors_count = 0
@@ -289,10 +289,10 @@ def _adapt_value_for_xlsx(fieldname, value, maximum_length=32767, _adapt=True):
     Return a two tuple of:
     (``value`` adapted for use in an XLSX cell, error message or None)
 
-    Convert the value to a string and performa these adaptations:
+    Convert the value to a string and perform these adaptations:
     - Keep only unique values in lists, preserving ordering.
     - Truncate the "description" field to the first five lines.
-    - Truncate any fieldtoo long to fit in an XLSX cell and report error.
+    - Truncate any field too long to fit in an XLSX cell and report error.
     - Create a combined license expression for expressions
     - Normalize line endings
     - Truncating the value to a ``maximum_length`` supported by XLSX.

--- a/scanpipe/tests/test_output.py
+++ b/scanpipe/tests/test_output.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# http://nexb.com and https://github.com/nexB/scancode.io
+# The ScanCode.io software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode.io is provided as-is without warranties.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Data Generated with ScanCode.io is provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+# ScanCode.io should be considered or used as legal advice. Consult an Attorney
+# for any legal advice.
+#
+# ScanCode.io is a free software code scanning tool from nexB Inc. and others.
+# Visit https://github.com/nexB/scancode.io for support and download.
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+import xlsxwriter
+from lxml import etree
+
+from scanpipe.pipes import output
+
+
+class ScanPipeOutputTest(TestCase):
+    data_location = Path(__file__).parent / "data"
+
+    def test__add_xlsx_worksheet_does_truncates_long_strings_over_max_len(self):
+        # This test verifies that we do not truncate long text silently
+
+        test_dir = Path(tempfile.mkdtemp(prefix="scancode-io-test"))
+
+        # The max length that Excel supports is 32,767 char per cell.
+        # and 253 linefeed. This does not seem to be an absolute science
+        # though.
+        len_32760_string = "f" * 32760
+        len_10_string = "0123456789"
+
+        values = get_cell_texts(
+            original_text=len_32760_string + len_10_string,
+            test_dir=test_dir,
+            workbook_name="long-text",
+        )
+
+        expected = [
+            None,
+            None,
+            "foo",
+            None,
+            "xlsx_errors",
+            None,
+            "fffffffffffffffffffffffffffffffffffffffffff0123456",
+            None,
+            "32767 length to fit in an XLSL cell maximum length",
+        ]
+
+        for r, x in zip(values, expected):
+            if r != x:
+                self.assertEqual(r[-50:], x)
+
+    def test__add_xlsx_worksheet_does_not_munge_long_strings_of_over_1024_lines(self):
+        # This test verifies that we do not truncate long text silently
+
+        test_dir = Path(tempfile.mkdtemp(prefix="scancode-io-test"))
+
+        len_1025_lines = "\r\n".join(str(i) for i in range(1025)) + "abcd"
+
+        values = get_cell_texts(
+            original_text=len_1025_lines,
+            test_dir=test_dir,
+            workbook_name="long-text",
+        )
+        expected = [
+            None,
+            None,
+            "foo",
+            None,
+            "xlsx_errors",
+            None,
+            "5\n1016\n1017\n1018\n1019\n1020\n1021\n1022\n1023\n1024abcd",
+            None,
+            "The value of: foo has been truncated from: 65476 to 32767 length to fit in an XLSL cell maximum length",
+        ]
+
+        for r, x in zip(values, expected):
+            if r != x:
+                self.assertEqual(r[-50:], x)
+
+    def test__adapt_value_for_xlsx_does_adapt(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="foo",
+            value="some simple value",
+        )
+        self.assertEqual(result, "some simple value")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_to_string(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="foo",
+            value=12.4,
+        )
+        self.assertEqual(result, "12.4")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_crlf_to_lf(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="foo",
+            value="some \r\nsimple \r\nvalue\r\n",
+        )
+        self.assertEqual(result, "some \nsimple \nvalue\n")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_license_expressions(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="license_expressions", value=["mit", "mit", "gpl-2.0"]
+        )
+        self.assertEqual(result, "mit AND gpl-2.0")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_description_and_keeps_only_5_lines(self):
+        twenty_lines = "\r\n".join(str(i) for i in range(20))
+
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="description", value=twenty_lines
+        )
+        self.assertEqual(result, "0\n1\n2\n3\n4")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_copyrights(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="copyrights",
+            value=[{"value": "bar"}, {"value": "foo"}, {"value": "bar"}],
+        )
+        self.assertEqual(result, "bar\nfoo")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_authors(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="authors",
+            value=[{"value": "bar"}, {"value": "foo"}, {"value": "bar"}],
+        )
+        self.assertEqual(result, "bar\nfoo")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_holders(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="holders",
+            value=[{"value": "bar"}, {"value": "foo"}, {"value": "bar"}],
+        )
+        self.assertEqual(result, "bar\nfoo")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_emails(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="emails", value=[{"email": "foo@bar.com"}]
+        )
+        self.assertEqual(result, "foo@bar.com")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_urls(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="urls", value=[{"url": "http://bar.com"}]
+        )
+        self.assertEqual(result, "http://bar.com")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_dicts(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="somename", value={"value1": "bar", "value2": "foo"}
+        )
+        self.assertEqual(result, "value1: bar\nvalue2: foo\n")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_lists(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="somename", value=["value1", "bar", "value2", "foo"]
+        )
+        self.assertEqual(result, "value1\nbar\nvalue2\nfoo")
+        self.assertEqual(error, None)
+
+    def test__adapt_value_for_xlsx_does_adapt_tuples_and_removes_dueps(self):
+        result, error = output._adapt_value_for_xlsx(
+            fieldname="somename", value=["value1", "bar", "value1", "foo"]
+        )
+        self.assertEqual(result, "value1\nbar\nfoo")
+        self.assertEqual(error, None)
+
+
+def get_cell_texts(original_text, test_dir, workbook_name):
+    """
+    Create a workbook with a worksheet with a cell with ``original_text``
+    and then extract, read and return the actual texts as a list.
+    """
+
+    class Row:
+        """
+        A mock Row with a single attribute storing a long string
+        """
+
+        def __init__(self, foo):
+            self.foo = foo
+
+    rows = [Row(original_text)]
+
+    output_file = test_dir / workbook_name
+    with xlsxwriter.Workbook(str(output_file)) as workbook:
+        output._add_xlsx_worksheet(
+            workbook=workbook,
+            worksheet_name="packages",
+            rows=rows,
+            fields=["foo"],
+        )
+
+    extract_dir = test_dir / "extracted"
+    shutil.unpack_archive(
+        filename=output_file,
+        extract_dir=extract_dir,
+        format="zip",
+    )
+
+    # This XML doc contains the strings stored in cells and has this shape:
+    # <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    # <sst     xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    #      count="2" uniqueCount="2">
+    #   <si><t>foo</t></si>
+    #   <si><t>f0123456789</t></si>
+    # </sst>
+
+    shared_strings = extract_dir / "xl" / "sharedStrings.xml"
+    sstet = etree.parse(str(shared_strings))
+    # in our special case the text we care is the last element of the XML
+
+    print("shared_strings:", shared_strings)
+    return [t.text for t in sstet.getroot().iter()]

--- a/scanpipe/tests/test_output.py
+++ b/scanpipe/tests/test_output.py
@@ -240,5 +240,4 @@ def get_cell_texts(original_text, test_dir, workbook_name):
     sstet = etree.parse(str(shared_strings))
     # in our special case the text we care is the last element of the XML
 
-    print("shared_strings:", shared_strings)
     return [t.text for t in sstet.getroot().iter()]

--- a/scanpipe/tests/test_output.py
+++ b/scanpipe/tests/test_output.py
@@ -88,7 +88,8 @@ class ScanPipeOutputTest(TestCase):
             None,
             "5\n1016\n1017\n1018\n1019\n1020\n1021\n1022\n1023\n1024abcd",
             None,
-            "The value of: foo has been truncated from: 65476 to 32767 length to fit in an XLSL cell maximum length",
+            "The value of: foo has been truncated from: 65476 to 32767 length "
+            "to fit in an XLSL cell maximum length",
         ]
 
         for r, x in zip(values, expected):


### PR DESCRIPTION
XlsxWriter 
We now check that the content is correctly added before calling
XlsxWriter and report and error if the truncated can be truncated.
Several other adaptations of a cell content are done:

 - Create a combined license expression for expressions.
 - Keep only unique values in lists, preserving ordering.
 - Collect the main attribute of well known scan fields
 - Convert mappings to YAML.
 - Truncate the "description" field to the first five lines.
 - Convert anything unknown to string.
 - Normalize line endings
 - Truncate to a maximum_length any field too long to fit in an XLSX
   cell and report error.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>