### PR TITLE
Use rpm.package_getter for photon images

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@
   calling XlsxWriter and report and error if the truncated can be truncated.
   https://github.com/nexB/scancode.io/issues/206
 
+- Add support for VMWare Photon-based Docker images and rootfs. This is an RPM-based
+  Linux distribution
+
 ### v21.6.10
 
 - Add support for VM image formats extraction such as VMDK, VDI and QCOW.

--- a/scanpipe/pipes/rootfs.py
+++ b/scanpipe/pipes/rootfs.py
@@ -47,6 +47,7 @@ PACKAGE_GETTER_BY_DISTRO = {
     "sles": rpm.package_getter,
     "opensuse": rpm.package_getter,
     "opensuse-tumbleweed": rpm.package_getter,
+    "photon": rpm.package_getter,
 }
 
 


### PR DESCRIPTION
This PR enables getting system packages from Photon OS distros.