### PR TITLE
Add pipeline publishing section in docs

### DIFF
--- a/docs/custom-pipelines.rst
+++ b/docs/custom-pipelines.rst
@@ -177,6 +177,8 @@ specify the entry point of the pipeline in the :guilabel:`setup.cfg` file.
     Remember to replace ``pipeline_module`` with the name of the Python module
     containing your custom pipeline.
 
+.. _pipeline_packaging_example:
+
 Pipeline Packaging Example
 --------------------------
 The example below shows a standard pipeline packaging procedure for the custom
@@ -249,5 +251,58 @@ the entry point to the pipeline under the ``[options.entry_points]`` section.
         pipeline_name = scancodeio_scan_and_report_pipeline.pipelines.scan_and_report:ScanAndReport
 
 .. tip::
-    Take a look at `Google LicenseClassifier pipeline for Scancode.io <https://github.com/nexB/scancode.io-pipeline-glc_scan>`_
+    Take a look at `Google License Classifier pipeline for Scancode.io <https://github.com/nexB/scancode.io-pipeline-glc_scan>`_
     for a complete example on packaging a custom tool as a pipeline.
+
+Pipeline Publishing to PyPI
+---------------------------
+After successfully packaging a pipeline, you may consider distributing it—as a plugin—via PyPI.
+Ensure a directory structure similar to the :ref:`pipeline_packaging_example` with all
+package files correctly configured.
+
+.. tip::
+    See the `Python packaging tutorial at PyPA <https://packaging.python.org/tutorials/packaging-projects/>`_
+    for a detailed setup guide.
+
+Next step involves generating the distribution archives for the package. Make sure you have the
+latest version of
+``build`` installed on your system
+
+.. code-block:: bash
+
+    pip install --upgrade build
+
+Now run the following command from within the same directory where the :guilabel:`pyproject.toml` is
+located:
+
+.. code-block:: bash
+
+    python -m build
+
+Once completed, you should have two files inside the ``dist`` directory with the
+``.tar.gz`` and ``.whl`` extensions.
+
+.. note::
+    Remember to create an account on `PyPI <https://pypi.org/>`_ before uploading your distribution archive to PyPI.
+
+You can use ``twine`` to upload the package to PyPI. To install twine, run the following command:
+
+.. code-block:: bash
+
+    pip install twine
+
+Finally, you can upload your package to PyPI with the next command
+
+.. code-block:: bash
+
+    twine upload dist/*
+
+Once successfully uploaded, your pipeline package should be viewable on PyPI under the name
+specified in your manifest.
+
+To make your pipeline available in ScanCode.io, you need to install the package from PyPI. For
+example, to download the package described in the :ref:`pipeline_packaging_example`, run
+
+.. code-block:: bash
+
+    bin/pip install scancodeio_scan_and_report_pipeline


### PR DESCRIPTION
Add a new document section describing the publication of a pipeline package to PyPI.
Closes #267 

Signed-off-by: Avishrant Sharma <avishrants@gmail.com>