### PR TITLE
The `run_scancode` pipe now uses an optimal number of available CPUs #302

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 // Release notes
 // -------------
 
+### Unreleased
+
+- The `scancode.run_scancode` pipe now uses an optimal number of available CPUs for
+  multiprocessing by default.
+  The exact number of parallel processes available to ScanCode.io can be defined
+  using the SCANCODEIO_PROCESSES setting.
+
+- Renamed the SCANCODE_DEFAULT_OPTIONS setting to SCANCODE_TOOLKIT_CLI_OPTIONS.
+
 ### v21.8.2
 
 - Upgrade ScanCode-toolkit to version 21.7.30

--- a/docs/scancodeio-settings.rst
+++ b/docs/scancodeio-settings.rst
@@ -59,33 +59,32 @@ See :ref:`project_workspace` for more details.
 SCANCODEIO_PROCESSES
 --------------------
 
-By default, multiprocessing is enabled and configured to use the number of CPUs
-available on the machine minus 1. You can control the number of parallel
-processes available to ScanCode.io using the SCANCODE_PROCESSES setting::
+By default, multiprocessing is enabled and configured to use an optimal number of CPUs
+available on the machine. You can control the number of parallel processes available
+to ScanCode.io using the SCANCODEIO_PROCESSES setting::
 
-    SCANCODE_PROCESSES=4
+    SCANCODEIO_PROCESSES=4
 
 Multiprocessing can be disabled entirely using "0"::
 
-    SCANCODE_PROCESSES=0
+    SCANCODEIO_PROCESSES=0
 
 To disable both multiprocessing and threading, use "-1"::
 
-    SCANCODE_PROCESSES=-1
+    SCANCODEIO_PROCESSES=-1
 
-SCANCODE_DEFAULT_OPTIONS
-------------------------
+SCANCODE_TOOLKIT_CLI_OPTIONS
+----------------------------
 
-Use this setting to provide any default options for running Scancode-toolkit.
+Use this setting to provide any default options for running ScanCode-toolkit.
 
 .. note::
     Refer to `ScanCode-toolkit Available Options <https://scancode-toolkit.readthedocs.io/en/latest/cli-reference/list-options.html>`_
     for the full list of available options.
 
-The following example explicitly defines a timeout value of 120 and sets the number
-of parallel processes to 4::
+The following example explicitly defines a timeout value of 60::
 
-    SCANCODE_DEFAULT_OPTIONS=--processes 4,--timeout 120
+    SCANCODE_TOOLKIT_CLI_OPTIONS=--timeout 60
 
 .. _scancodeio_settings_pipelines_dirs:
 

--- a/scancodeio/settings/base.py
+++ b/scancodeio/settings/base.py
@@ -45,10 +45,11 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=[".localhost", "127.0.0.1", "[
 
 SCANCODEIO_WORKSPACE_LOCATION = env.str("SCANCODEIO_WORKSPACE_LOCATION", default="var")
 
-SCANCODE_DEFAULT_OPTIONS = env.list("SCANCODE_DEFAULT_OPTIONS", default=[])
+SCANCODE_TOOLKIT_CLI_OPTIONS = env.list("SCANCODE_TOOLKIT_CLI_OPTIONS", default=[])
 
 # Set the number of parallel processes to use for ScanCode related scan execution.
-# If the SCANCODE_PROCESSES argument is not set, defaults to the number of CPUs minus 1.
+# If the SCANCODEIO_PROCESSES argument is not set, defaults to an optimal number of CPUs
+# available on the machine.
 SCANCODEIO_PROCESSES = env.int("SCANCODEIO_PROCESSES", default=None)
 
 SCANCODEIO_POLICIES_FILE = env.str("SCANCODEIO_POLICIES_FILE", default="policies.yml")

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -55,7 +55,7 @@ Utilities to deal with ScanCode objects, in particular Codebase and Package.
 scanpipe_app = apps.get_app_config("scanpipe")
 
 
-def get_max_workers(keep_available=1):
+def get_max_workers(keep_available):
     """
     Returns the `SCANCODEIO_PROCESSES` if defined in the setting,
     or returns a default value based on the number of available CPUs, minus the
@@ -316,7 +316,7 @@ def run_scancode(location, output_file, options, raise_on_error=False):
     exitcode is greater than 0.
     """
     options_from_settings = getattr(settings, "SCANCODE_TOOLKIT_CLI_OPTIONS", [])
-    max_workers = get_max_workers(keep_available=4)
+    max_workers = get_max_workers(keep_available=1)
 
     scancode_args = [
         pipes.get_bin_executable("scancode"),

--- a/scanpipe/tests/test_pipes.py
+++ b/scanpipe/tests/test_pipes.py
@@ -518,11 +518,6 @@ class ScanPipePipesTest(TestCase):
             scancode.run_scancode(location=None, output_file=None, options=[])
             self.assertIn("--timeout 60", mock_run_command.call_args[0][0])
 
-        with override_settings(SCANCODEIO_PROCESSES=None):
-            scancode.run_scancode(location=None, output_file=None, options=[])
-            expected = os.cpu_count() - 4
-            self.assertIn(f"--processes {expected}", mock_run_command.call_args[0][0])
-
         with override_settings(SCANCODEIO_PROCESSES=10):
             scancode.run_scancode(location=None, output_file=None, options=[])
             self.assertIn("--processes 10", mock_run_command.call_args[0][0])


### PR DESCRIPTION
The exact number of parallel processes available to ScanCode.io can be defined using the SCANCODEIO_PROCESSES setting.

Signed-off-by: Thomas Druez <tdruez@nexb.com>