### PR TITLE
Fixing extensible text box commit

### DIFF
--- a/scanpipe/templates/scanpipe/base.html
+++ b/scanpipe/templates/scanpipe/base.html
@@ -33,7 +33,7 @@
       .is-black-link {color: #363636;}
       .is-grey-link {color: #7a7a7a;}
       .is-black-link:hover, .is-grey-link:hover {color: #3273dc; text-decoration: underline;}
-      #project-extra-data figure.highlight {max-height: 300px; overflow-y: scroll;}
+      #project-extra-data figure.highlight {max-height: 300px; overflow-y: auto; overflow-x: auto;}
       #project-extra-data pre {background-color: initial; color: initial; padding: initial; white-space: pre-wrap;}
       #inputs-panel .panel-block.dropdown:hover {background-color: #f5f5f5;}
       #inputs-panel .dropdown-menu {width: 85%;}


### PR DESCRIPTION
Basically the reason why the text box was uncanny was because the overflow of the text in both direction was set to scroll allowing the user to scroll the text under project data by changing it to auto creates an extensible text box for the project data