### PR TITLE
[WIP] Add OIDC via mozilla-django-oidc

### DIFF
--- a/scancodeio/context_processors.py
+++ b/scancodeio/context_processors.py
@@ -24,9 +24,14 @@ from scancode_config import __version__ as scancode_toolkit_version
 
 from scancodeio import __version__ as scancodeio_version
 
+from scancodeio.settings import SCANCODEIO_AUTHENTICATION_METHOD
+
 
 def versions(request):
     return {
         "SCANCODEIO_VERSION": scancodeio_version,
         "SCANCODE_TOOLKIT_VERSION": scancode_toolkit_version,
     }
+
+def auth(request):
+    return { "SCANCODEIO_AUTHENTICATION_METHOD": str(SCANCODEIO_AUTHENTICATION_METHOD) }

--- a/scancodeio/urls.py
+++ b/scancodeio/urls.py
@@ -45,6 +45,7 @@ auth_urlpatterns = [
         name="logout",
     ),
     path("accounts/profile/", AccountProfileView.as_view(), name="account_profile"),
+    path('oidc/', include('mozilla_django_oidc.urls')),
 ]
 
 urlpatterns = auth_urlpatterns + [

--- a/scanpipe/templates/scanpipe/includes/navbar_header.html
+++ b/scanpipe/templates/scanpipe/includes/navbar_header.html
@@ -15,42 +15,64 @@
     </div>
   </div>
   <div class="navbar-end mr-3">
-    {% if user.is_authenticated %}
-      <div class="navbar-item has-dropdown is-hoverable">
-        <a class="navbar-link">
-          {{ user.username }}
-        </a>
-        <div class="navbar-dropdown is-right">
-          <a class="navbar-item" href="{% url 'account_profile' %}">
-            Profile settings
-          </a>
-          <a class="navbar-item" href="{% url 'logout' %}">
-            Sign out
-          </a>
-          <hr class="navbar-divider">
-          <div class="navbar-item">
-            <i>ScanCode.io {{ SCANCODEIO_VERSION }}</i>
-          </div>
-          <div class="navbar-item">
-            <i>ScanCode-toolkit {{ SCANCODE_TOOLKIT_VERSION }}</i>
-          </div>
+    {% if not user.is_authenticated %}
+    <div class="navbar-item navbar-item is-cursor-help">
+      <div class="dropdown is-right is-hoverable">
+        <div class="dropdown-trigger has-text-grey-light">
+          v{{ SCANCODEIO_VERSION }}
         </div>
-      </div>
-    {% else %}
-      <div class="navbar-item navbar-item is-cursor-help">
-        <div class="dropdown is-right is-hoverable">
-          <div class="dropdown-trigger has-text-grey-light">
-            v{{ SCANCODEIO_VERSION }}
-          </div>
-          <div class="dropdown-menu" role="menu" style="min-width: 13rem;">
-            <div class="dropdown-content">
-              <div class="dropdown-item">
-                ScanCode-toolkit: v{{ SCANCODE_TOOLKIT_VERSION }}
-              </div>
+        <div class="dropdown-menu" role="menu" style="min-width: 13rem;">
+          <div class="dropdown-content">
+            <div class="dropdown-item">
+              ScanCode-toolkit: v{{ SCANCODE_TOOLKIT_VERSION }}
             </div>
           </div>
         </div>
       </div>
+    </div>
+    {% elif SCANCODEIO_AUTHENTICATION_METHOD == "OIDC" %}
+        <div class="navbar-item has-dropdown is-hoverable">
+          <a class="navbar-link">
+            {{ user.email }}
+          </a>
+          <div class="navbar-dropdown is-right">
+            <a class="navbar-item" href="{% url 'account_profile' %}">
+              Profile settings
+            </a>
+            <form action="{% url 'oidc_logout' %}" method="post">
+              {% csrf_token %}
+              <input class="navbar-item" type="submit" value="Sign out">
+            </form>
+            <hr class="navbar-divider">
+            <div class="navbar-item">
+              <i>ScanCode.io {{ SCANCODEIO_VERSION }}</i>
+            </div>
+            <div class="navbar-item">
+              <i>ScanCode-toolkit {{ SCANCODE_TOOLKIT_VERSION }}</i>
+            </div>
+          </div>
+        </div>
+      {% else %}
+        <div class="navbar-item has-dropdown is-hoverable">
+          <a class="navbar-link">
+            {{ user.username }}
+          </a>
+          <div class="navbar-dropdown is-right">
+            <a class="navbar-item" href="{% url 'account_profile' %}">
+              Profile settings
+            </a>
+            <a class="navbar-item" href="{% url 'logout' %}">
+              Sign out
+            </a>
+            <hr class="navbar-divider">
+            <div class="navbar-item">
+              <i>ScanCode.io {{ SCANCODEIO_VERSION }}</i>
+            </div>
+            <div class="navbar-item">
+              <i>ScanCode-toolkit {{ SCANCODE_TOOLKIT_VERSION }}</i>
+            </div>
+          </div>
+        </div>
     {% endif %}
   </div>
 </nav>

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,8 @@ install_requires =
     rq==1.10.1
     django-rq==2.5.1
     redis==4.0.2
+    # Auth
+    mozilla_django_oidc==2.0.0
     # WSGI server
     gunicorn==20.1.0
     # Docker


### PR DESCRIPTION
This is something we use at scancode.onap.eu

mozilla-django-oidc is a minimal lib and does not implement stuff like:
- verify e-mail
- connect multiple accounts to single django account

this solution creates a user with preferred_username as username which might not be unique
by default (mozilla-django-oidc) username is a hash of e-mail (im not 100% sure but its not important)

I'm currently testing different solutions (django-allauth, python social login) that would handle above but thought to submit this as a follow up to #336 as we are currently using it