### PR TITLE
Add django-probes for wait_for_database

### DIFF
--- a/scancodeio/settings.py
+++ b/scancodeio/settings.py
@@ -92,6 +92,7 @@ INSTALLED_APPS = (
     "rest_framework",
     "rest_framework.authtoken",
     "django_rq",
+    "django_probes",
 )
 
 MIDDLEWARE = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     # Database
     psycopg2==2.9.2; sys_platform == "linux"
     psycopg2-binary==2.9.2; sys_platform != "linux"
+    django_probes==1.6.0
     # Task queue
     rq==1.10.1
     django-rq==2.5.1


### PR DESCRIPTION
This feature is nice-to-have for Kubernetes/OpenShift deployments making
start up of app more streamlined by giving ability for K8s/OS to hold off running
 app until database is up.

As per it's docs it supports all db engines that Django supports:
https://pypi.org/project/django-probes/
License: BSD-3-Clause

Related: #335