### PR TITLE
Upgraded to Django 4 and other related modules also

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - name: Checkout code

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ classifiers =
     Intended Audience :: Legal Industry
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Utilities
@@ -45,7 +43,7 @@ license_files =
     scan.NOTICE
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 packages=find:
 include_package_data = true
 zip_safe = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,6 @@ install_requires =
     Django==4.0.3
     django-environ==0.8.1
     django-crispy-forms==1.14.0
-    # Upgrading pytz to 2021.3 breaks the pip resolver
-    pytz==2022.1
     django-filter==21.1
     djangorestframework==3.13.1
     # Database

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,13 +53,13 @@ install_requires =
     # Warning: the importlib_metadata 4.6.x series breaks the documentation builds
     importlib_metadata==3.10.0; python_version < "3.8"
     # Django related
-    Django==3.2.10
+    Django==4.0.3
     django-environ==0.8.1
-    django-crispy-forms==1.13.0
+    django-crispy-forms==1.14.0
     # Upgrading pytz to 2021.3 breaks the pip resolver
-    pytz==2021.1
+    pytz==2022.1
     django-filter==21.1
-    djangorestframework==3.13.0
+    djangorestframework==3.13.1
     # Database
     psycopg2==2.9.2; sys_platform == "linux"
     psycopg2-binary==2.9.2; sys_platform != "linux"


### PR DESCRIPTION
Upgraded to Django 4.0.3 and other modules to the latest version.

Changes in Django 4.0 releases:
* Python compatibility
  Django 4.0 supports Python 3.8, 3.9, and 3.10. I have removed Python 3.6 and Python 3.7 from `setup.cfg` and updated CI

* zoneinfo default timezone implementation
  The Python standard library’s [zoneinfo](https://docs.python.org/3/library/zoneinfo.html#module-zoneinfo) is now the default timezone implementation in Django. I have removed `pytz` from the requirements. [zoneinfo](https://docs.python.org/3/library/zoneinfo.html#module-zoneinfo) is part of the Python standard library from Python 3.9. The backports.zoneinfo package is automatically installed alongside Django if you are using Python 3.8.
The present version of the codebase is using the `timezone` imported from `django.utils` for getting the present time using `timezone.now()` which works fine as previous in this newer version. [Reference](https://docs.djangoproject.com/en/4.0/topics/i18n/timezones/#time-zones)

* Minor Features
  1. [https://docs.djangoproject.com/en/4.0/releases/4.0/#csrf](https://docs.djangoproject.com/en/4.0/releases/4.0/#csrf)
    The changes mentioned in this feature are related to [CSRF_TRUSTED_ORIGINS](https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS) settings which our codebase is not concerned with. 

  2. [https://docs.djangoproject.com/en/4.0/releases/4.0/#requests-and-responses](https://docs.djangoproject.com/en/4.0/releases/4.0/#requests-and-responses)
    The changes mentioned in this feature are related to [SECURE_CROSS_ORIGIN_OPENER_POLICY](https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-SECURE_CROSS_ORIGIN_OPENER_POLICY) settings which also doesn't affect any change in our dependencies.

  3. [https://docs.djangoproject.com/en/4.0/releases/4.0/#csrf-trusted-origins-changes](https://docs.djangoproject.com/en/4.0/releases/4.0/#csrf-trusted-origins-changes) and [https://docs.djangoproject.com/en/4.0/releases/4.0/#configuring-it-may-now-be-required](https://docs.djangoproject.com/en/4.0/releases/4.0/#configuring-it-may-now-be-required) 
    For the changes in [CSRF_TRUSTED_ORIGINS](https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS) settings, no changes are we are including `csrf_token` in every form requests like of POST methods. 

  4. [https://docs.djangoproject.com/en/4.0/releases/4.0/#securitymiddleware-no-longer-sets-the-x-xss-protection-header](https://docs.djangoproject.com/en/4.0/releases/4.0/#securitymiddleware-no-longer-sets-the-x-xss-protection-header)
    No changes are required. 

Resolves #384 

Signed-off-by: Pratyush1606 <jaiswalpratyush2015@gmail.com>