### PR TITLE
Get copyright and holder values from proper fields

### DIFF
--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -440,8 +440,8 @@ class ProjectDetailView(ConditionalLoginRequired, ProjectViewMixin, generic.Deta
 
         file_languages = files.values_list("programming_language", flat=True)
         file_mime_types = files.values_list("mime_type", flat=True)
-        file_holders = self.data_from_model_field(files, "holders", "value")
-        file_copyrights = self.data_from_model_field(files, "copyrights", "value")
+        file_holders = self.data_from_model_field(files, "holders", "holder")
+        file_copyrights = self.data_from_model_field(files, "copyrights", "copyright")
         file_license_keys = self.data_from_model_field(files, "licenses", "key")
         file_license_categories = self.data_from_model_field(
             files, "licenses", "category"


### PR DESCRIPTION
This PR addresses #502 where the detected copyright and holder values did not show up as keys in the Project detail view's donut charts.