### PR TITLE
Upgrade ScanCode-toolkit to v31.0.1, Django to 4.1, and dependencies …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,11 +5,11 @@ v31.0.0 (next)
 ---------------
 
 - WARNING: Drop support for Python 3.6 and 3.7. Add support for Python 3.10.
-  Upgrade Django to version 4.x series.
+  Upgrade Django to version 4.1 series.
 
-- Upgrade ScanCode-toolkit to version v31.
+- Upgrade ScanCode-toolkit to version 31.0.1.
   See https://github.com/nexB/scancode-toolkit/blob/develop/CHANGELOG.rst for an
-  overview of the changes in v31 compared to v30.
+  overview of the changes in the v31 compared to v30.
 
 - Implement run status auto-refresh using the htmx JavaScript library.
   The statuses of queued and running pipeline are now automatically refreshed

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -170,7 +170,7 @@ Before you install ScanCode.io, make sure you have the following prerequisites:
 
  * **Python: versions 3.8 to 3.10** found at https://www.python.org/downloads/
  * **Git**: most recent release available at https://git-scm.com/
- * **PostgreSQL**: release 10 or later found at https://www.postgresql.org/ or
+ * **PostgreSQL**: release 11 or later found at https://www.postgresql.org/ or
    https://postgresapp.com/ on macOS
 
 .. _system_dependencies:

--- a/etc/thirdparty/virtualenv.pyz.ABOUT
+++ b/etc/thirdparty/virtualenv.pyz.ABOUT
@@ -1,7 +1,7 @@
 about_resource: virtualenv.pyz
 name: get-virtualenv
-version: 20.15.1
-download_url: https://github.com/pypa/get-virtualenv/raw/20.15.1/public/virtualenv.pyz
+version: 20.16.3
+download_url: https://github.com/pypa/get-virtualenv/raw/20.16.3/public/virtualenv.pyz
 description: virtualenv is a tool to create isolated Python environments.
 homepage_url: https://github.com/pypa/virtualenv
 license_expression: lgpl-2.1-plus AND (bsd-new OR apache-2.0) AND mit AND python AND bsd-new
@@ -10,4 +10,4 @@ copyright: Copyright (c) The Python Software Foundation and others
 redistribute: yes
 attribute: yes
 track_changes: yes
-package_url: pkg:github/pypa/get-virtualenv@20.15.1#public/virtualenv.pyz
+package_url: pkg:github/pypa/get-virtualenv@20.16.3#public/virtualenv.pyz

--- a/scancodeio/__init__.py
+++ b/scancodeio/__init__.py
@@ -30,9 +30,9 @@ __version__ = "30.2.0"
 SCAN_NOTICE = Path(__file__).resolve().parent.joinpath("scan.NOTICE").read_text()
 
 
-# Turn off the warnings from the `parameter_expansion` and `cluecode` modules.
-warnings.filterwarnings("ignore", module="parameter_expansion")
-warnings.filterwarnings("ignore", module="cluecode")
+# Turn off the warnings for the following modules.
+warnings.filterwarnings("ignore", module="extractcode")
+warnings.filterwarnings("ignore", module="typecode")
 
 
 def command_line():

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -234,6 +234,8 @@ class PipelinesIntegrationTest(TestCase):
         # system_environment differs between systems
         "system_environment",
         "file_type",
+        # mime type is inconsistent across systems
+        "mime_type",
     ]
 
     def _without_keys(self, data, exclude_keys):

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ zip_safe = false
 install_requires =
     importlib_metadata==4.12.0
     # Django related
-    Django==4.0.6
+    Django==4.1
     django-environ==0.9.0
     django-crispy-forms==1.14.0
     django-filter==22.1
@@ -60,9 +60,9 @@ install_requires =
     psycopg2==2.9.3; sys_platform == "linux"
     psycopg2-binary==2.9.3; sys_platform != "linux"
     # wait_for_database Django management command
-    django_probes==1.6.0
+    django_probes==1.7.0
     # Task queue
-    rq==1.10.1
+    rq==1.11.0
     django-rq==2.5.1
     redis==4.3.4
     # WSGI server
@@ -70,7 +70,7 @@ install_requires =
     # Docker
     container_inspector==32.0.1
     # ScanCode-toolkit
-    scancode-toolkit[packages]==31.0.0rc5
+    scancode-toolkit[packages]==31.0.1
     extractcode[full]==31.0.0
     commoncode==31.0.0b4
     # FetchCode
@@ -84,7 +84,7 @@ install_requires =
 [options.extras_require]
 dev =
     # Validation
-    pycodestyle==2.8.0
+    pycodestyle==2.9.1
     black==22.6.0
     isort==5.10.1
     doc8==0.11.2


### PR DESCRIPTION
…to latest #494

Signed-off-by: Thomas Druez <tdruez@nexb.com>