### PR TITLE
Changing file's Line-Break Control Charecters to avoid (CR LF) error in Windows.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python 
 if __name__ == "__main__":
     from scancodeio import command_line
-
     command_line()


### PR DESCRIPTION
Changed manage.py, Changed line brakes -> Windows(CR LF) to Unix(LF), in regards to Issue #412 and Issue #518 .