### PR TITLE
Escape path before creating regex pattern #525

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ v31.1.0 (unreleased)
 - Create directory CodebaseResources in the rootfs pipeline.
   https://github.com/nexB/scancode.io/issues/515
 
+- Escape paths before using them in regular expressions in ``CodebaseResource.walk()``.
+  https://github.com/nexB/scancode.io/issues/525
+
 v31.0.0 (2022-08-25)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,11 @@ v31.1.0 (unreleased)
 - Create directory CodebaseResources in the rootfs pipeline.
   https://github.com/nexB/scancode.io/issues/515
 
+- Add ProjectErrors when the DiscoveredPackage could not be fetched using the
+  provided `package_uid` during the `assemble_package` step instead of failing the whole
+  pipeline.
+  https://github.com/nexB/scancode.io/issues/525
+
 - Escape paths before using them in regular expressions in ``CodebaseResource.walk()``.
   https://github.com/nexB/scancode.io/issues/525
 

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -1742,7 +1742,8 @@ class CodebaseResource(
         with the commoncode.resource.VirtualCodebase class API.
         """
         exactly_one_sub_directory = "[^/]+$"
-        children_regex = rf"^{self.path}/{exactly_one_sub_directory}"
+        escaped_path = re.escape(self.path)
+        children_regex = rf"^{escaped_path}/{exactly_one_sub_directory}"
         return (
             self.descendants()
             .filter(path__regex=children_regex)

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -1246,6 +1246,21 @@ class ScanPipeModelsTest(TestCase):
         asgiref_resource_siblings = [r.path for r in asgiref_resource.siblings()]
         self.assertEqual(sorted(expected_siblings), sorted(asgiref_resource_siblings))
 
+    def test_scanpipe_codebase_resource_model_walk_method_problematic_filenames(self):
+        project = Project.objects.create(name="walk_test_problematic_filenames")
+        resource1 = CodebaseResource.objects.create(
+            project=project, path="qt-everywhere-opensource-src-5.3.2/gnuwin32/bin"
+        )
+        resource2 = CodebaseResource.objects.create(
+            project=project,
+            path="qt-everywhere-opensource-src-5.3.2/gnuwin32/bin/flex++.exe",
+        )
+        expected_paths = [
+            "qt-everywhere-opensource-src-5.3.2/gnuwin32/bin/flex++.exe",
+        ]
+        result = [r.path for r in resource1.walk()]
+        self.assertEqual(expected_paths, result)
+
     @mock.patch("requests.post")
     def test_scanpipe_webhook_subscription_send_method(self, mock_post):
         webhook = self.project1.add_webhook_subscription("https://localhost")

--- a/scanpipe/tests/test_pipes.py
+++ b/scanpipe/tests/test_pipes.py
@@ -1271,7 +1271,7 @@ class ScanPipePipesTransactionTest(TransactionTestCase):
         self.assertEqual(1, project1.projecterrors.count())
         error = project1.projecterrors.get()
         self.assertEqual("assemble_package", error.model)
-        expected = {'resource': 'filename.ext', 'package_uid': 'not_available'}
+        expected = {"resource": "filename.ext", "package_uid": "not_available"}
         self.assertEqual(expected, error.details)
 
         scancode.add_resource_to_package(package1.package_uid, resource1, project1)

--- a/scanpipe/tests/test_pipes.py
+++ b/scanpipe/tests/test_pipes.py
@@ -1254,7 +1254,7 @@ class ScanPipePipesTransactionTest(TransactionTestCase):
         self.assertEqual(1, p1.codebaseresources.count())
         self.assertEqual(0, p1.projecterrors.count())
 
-    def test_scanpipe_add_to_package(self):
+    def test_scanpipe_add_resource_to_package(self):
         project1 = Project.objects.create(name="Analysis")
         resource1 = CodebaseResource.objects.create(
             project=project1,
@@ -1263,14 +1263,22 @@ class ScanPipePipesTransactionTest(TransactionTestCase):
         package1 = update_or_create_package(project1, package_data1)
         self.assertFalse(resource1.for_packages)
 
-        self.assertIsNone(scancode.add_to_package(None, resource1, project1))
+        self.assertIsNone(scancode.add_resource_to_package(None, resource1, project1))
         self.assertFalse(resource1.for_packages)
 
-        scancode.add_to_package(package1.package_uid, resource1, project1)
+        scancode.add_resource_to_package("not_available", resource1, project1)
+        self.assertFalse(resource1.for_packages)
+        self.assertEqual(1, project1.projecterrors.count())
+        error = project1.projecterrors.get()
+        self.assertEqual("assemble_package", error.model)
+        expected = {'resource': 'filename.ext', 'package_uid': 'not_available'}
+        self.assertEqual(expected, error.details)
+
+        scancode.add_resource_to_package(package1.package_uid, resource1, project1)
         self.assertEqual(len(resource1.for_packages), 1)
         self.assertIn(package1.package_uid, resource1.for_packages)
 
         # Package will not be added twice since it is already associated with the
         # resource.
-        scancode.add_to_package(package1.package_uid, resource1, project1)
+        scancode.add_resource_to_package(package1.package_uid, resource1, project1)
         self.assertEqual(len(resource1.for_packages), 1)


### PR DESCRIPTION
This fixes #525 by escaping the CodebaseResource path before using it to create the path regex pattern for child resources.