### PR TITLE
A Note for Windows users to set git autocrlf = false before cloning the repo to avoid issues like #518 .

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,6 +35,11 @@ Build the Image
 ScanCode.io is distributed with ``Dockerfile`` and ``docker-compose.yml`` files
 required for the creation of the Docker image.
 
+.. note::
+    If you are using Windows Operating System, before cloning the repository ensure that git's autocrlf is set to false
+    by using ``git config --global core.autocrlf false``.
+
+
 **Clone the git** `ScanCode.io repo <https://github.com/nexB/scancode.io>`_,
 create an **environment file**, and **build the Docker image**::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,6 @@ required for the creation of the Docker image.
     If you are using Windows Operating System, before cloning the repository ensure that git's autocrlf is set to false
     by using ``git config --global core.autocrlf false``.
 
-
 **Clone the git** `ScanCode.io repo <https://github.com/nexB/scancode.io>`_,
 create an **environment file**, and **build the Docker image**::
 


### PR DESCRIPTION
Git automatically converts LF to CR LF while cloning a repository. This was leading to CR LF errors in windows such as issue https://github.com/nexB/scancode.io/issues/518.
This error can be avoided altogether by just setting git's autocrlf to false.
Signed-off-by: 35C4n0r <jaykumar20march@gmail.com>