### PR TITLE
564 improve document describes spdx sbom

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v33.0.0 (unreleased)
+--------------------
+
+- Populate ``documentDescribes`` field with Package and Dependency SPDX IDs in
+  SPDX BOM output.
+  https://github.com/nexB/scancode.io/issues/564
+
 v32.0.0 (2022-11-29)
 --------------------
 

--- a/scanpipe/spdx/__init__.py
+++ b/scanpipe/spdx/__init__.py
@@ -578,7 +578,7 @@ class Document:
             "documentNamespace": self.namespace,
             "creationInfo": self.creation_info.as_dict(),
             "packages": [package.as_dict() for package in self.packages],
-            "documentDescribes": [self.spdx_id],
+            "documentDescribes": [package.spdx_id for package in self.packages],
         }
 
         if self.files:

--- a/scanpipe/spdx/test_spdx.py
+++ b/scanpipe/spdx/test_spdx.py
@@ -247,7 +247,7 @@ class SPDXTestCase(TestCase):
                     "licenseComments": "license_comments",
                 }
             ],
-            "documentDescribes": ["SPDXRef-DOCUMENT"],
+            "documentDescribes": ["SPDXRef-package1"],
             "hasExtractedLicensingInfos": [
                 {
                     "licenseId": "LicenseRef-1",

--- a/scanpipe/tests/data/asgiref-3.3.0.spdx.json
+++ b/scanpipe/tests/data/asgiref-3.3.0.spdx.json
@@ -116,7 +116,12 @@
     }
   ],
   "documentDescribes": [
-    "SPDXRef-DOCUMENT"
+    "SPDXRef-scancodeio-discoveredpackage-7f975593-4bdd-4217-8d04-3554d691f310",
+    "SPDXRef-scancodeio-discoveredpackage-edf75850-316d-4a46-9ca1-bde1f4fc3aab",
+    "SPDXRef-scancodeio-discovereddependency-pkg:pypi/pytest?uuid=6ef94d27-ae57-408e-baa4-e20e3dc1f1aa",
+    "SPDXRef-scancodeio-discovereddependency-pkg:pypi/pytest?uuid=4b195723-fe04-47c9-8b65-c08c60423c18",
+    "SPDXRef-scancodeio-discovereddependency-pkg:pypi/pytest-asyncio?uuid=87beebac-2c45-4adf-a700-a9a6ad1724e9",
+    "SPDXRef-scancodeio-discovereddependency-pkg:pypi/pytest-asyncio?uuid=26af7b66-1034-4e21-9a2a-6dc1616a34ec"
   ],
   "files": [],
   "relationships": [


### PR DESCRIPTION
This PR updates the SPDX BOM output to populate the `documentDescribes` field with the SPDX ID of the Packages and Dependencies found in a codebase.