### PR TITLE
Fix dependency issues

### DIFF
--- a/scanpipe/tests/data/is-npm-1.0.0_scan_package.json
+++ b/scanpipe/tests/data/is-npm-1.0.0_scan_package.json
@@ -20,7 +20,7 @@
       "errors": [],
       "warnings": [],
       "extra_data": {
-        "spdx_license_list_version": "3.17",
+        "spdx_license_list_version": "3.18",
         "files_count": 3
       }
     }

--- a/scanpipe/tests/data/multiple-is-npm-1.0.0_scan_package.json
+++ b/scanpipe/tests/data/multiple-is-npm-1.0.0_scan_package.json
@@ -20,7 +20,7 @@
       "errors": [],
       "warnings": [],
       "extra_data": {
-        "spdx_license_list_version": "3.17",
+        "spdx_license_list_version": "3.18",
         "files_count": 6
       }
     }

--- a/scanpipe/tests/data/package_assembly_codebase.json
+++ b/scanpipe/tests/data/package_assembly_codebase.json
@@ -27,7 +27,7 @@
           "platform_version": "#138~18.04.1-Ubuntu SMP Fri Jun 24 14:14:03 UTC 2022",
           "python_version": "3.10.4 (main, May 22 2022, 00:46:26) [GCC 7.5.0]"
         },
-        "spdx_license_list_version": "3.17",
+        "spdx_license_list_version": "3.18",
         "files_count": 3
       }
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ install_requires =
     # FetchCode
     fetchcode-container==1.2.3.210512; sys_platform == "linux"
     # Inspectors
-    python-inspector==0.9.2
+    python-inspector==0.9.4
     aboutcode-toolkit==7.2.0
     # Utilities
     XlsxWriter==3.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ install_requires =
     # Docker
     container_inspector==32.0.1
     # ScanCode-toolkit
-    scancode-toolkit[packages]==31.2.1
+    scancode-toolkit[packages]==31.2.4
     extractcode[full]==31.0.0
     commoncode==31.0.0
     # FetchCode


### PR DESCRIPTION
scancode-toolkit 31.2.3 and 31.2.4 has bugfixes for a number of dependency issues which was breaking toolkit and others. These dependency fixes were:

* spdx-tools has been pinned to `0.7.0a3` to guard against upcoming breaking changes.

* the installation issues with `packaging` version 22.0 is fixed by replacing it with `packvers`

* license index unpickling issue because of the new `attrs` release `22.2.0` is fixed by vendoring attrs for use in the license index code.

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>