### PR TITLE
made Text box  extensible #210

### DIFF
--- a/scanpipe/templates/scanpipe/base.html
+++ b/scanpipe/templates/scanpipe/base.html
@@ -37,7 +37,7 @@
       .is-black-link {color: #363636;}
       .is-grey-link {color: #7a7a7a;}
       .is-black-link:hover, .is-grey-link:hover {color: #3273dc; text-decoration: underline;}
-      #project-extra-data figure.highlight {max-height: 300px; overflow-y: scroll;}
+      #project-extra-data figure.highlight {max-height: 300px; overflow-y: auto; overflow-x : auto}
       #project-extra-data pre {background-color: initial; color: initial; padding: initial; white-space: pre-wrap; word-break: break-all;}
       #inputs-panel .panel-block.dropdown:hover {background-color: #f5f5f5;}
       #inputs-panel .dropdown-menu {width: 85%;}


### PR DESCRIPTION
issue: Project data text box should be extensible #210
As specified earlier [scancode.io/scanpipe/templates/scanpipe/project_detail.html] consisted of projects-extra-data and base.html had project-extra--data with overflow in y was set to scroll in the vertical direction with 300px maximum height. So basically the overflow-y: auto and overflow-x: auto properties will allow the scrollbar to appear only when necessary in both directions. Tried with different maximum heights and I think it is working fine.

