### PR TITLE
Refine documentation about the scanpipe command #616

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+v33.0.0 (unreleased)
+--------------------
+
+- Refine the "Command Line Interface" documentation about the ``scanpipe`` command
+  usages in the Docker context.
+  Add the /app workdir in the PYTHONPATH env of the Docker file to make the ``scanpipe``
+  entry point available while running ``docker compose`` commands.
+  https://github.com/nexB/scancode.io/issues/616
+
 v32.0.1 (2023-02-20)
 --------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,12 @@ FROM --platform=linux/amd64 python:3.9
 
 WORKDIR /app
 
-# Python settings: Force unbuffered stdout and stderr (i.e. they are flushed to terminal immediately)
+# Python settings: force unbuffered stdout and stderr (i.e. they are flushed to terminal immediately)
 ENV PYTHONUNBUFFERED 1
 # Python settings: do not write pyc files
 ENV PYTHONDONTWRITEBYTECODE 1
+# Add the workdir in the Python path for scancodeio modules availability in entry points
+ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 # OS requirements as per
 # https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html

--- a/docs/command-line-interface.rst
+++ b/docs/command-line-interface.rst
@@ -3,9 +3,18 @@
 Command Line Interface
 ======================
 
-The main entry point is the :guilabel:`scanpipe` command which is available
-directly when you are in the activated virtualenv or at this path:
-``<scancode.io_root_dir>/bin/scanpipe``
+A ``scanpipe`` command can be executed through the ``docker compose`` command line
+interface with::
+
+    docker compose exec -it web scanpipe COMMAND
+
+Alternatively, you can start a ``bash`` session in a new Docker container to execute
+multiple ``scanpipe`` commands::
+
+    docker compose run web bash
+    scanpipe COMMAND
+    scanpipe COMMAND
+    ...
 
 .. warning::
     In order to add local input files to a project using the Command Line Interface,
@@ -18,8 +27,12 @@ directly when you are in the activated virtualenv or at this path:
     .. code-block:: bash
 
         docker compose run --volume /home/sources:/sources:ro \
-            web ./manage.py create-project my-project --input-file="/sources/image.tar"
+            web scanpipe create-project my_project --input-file="/sources/image.tar"
 
+.. note::
+    In a local development installation, the ``scanpipe`` command is directly
+    available as an entry point in your virtualenv and is located at
+    ``<scancode.io_root_dir>/bin/scanpipe``.
 
 `$ scanpipe --help`
 -------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -98,20 +98,13 @@ An overview of the web application usage is available at :ref:`user_interface`.
 Execute a Command
 ^^^^^^^^^^^^^^^^^
 
-You can execute a one of ``scanpipe`` commands through the Docker command line
-interface, for example::
-
-    docker compose run web ./manage.py create-project project_name
-
 .. note::
     Refer to the :ref:`command_line_interface` section for the full list of commands.
 
-Alternatively, you can connect to the Docker container ``bash`` and run commands
-from there::
+A ``scanpipe`` command can be executed through the ``docker compose`` command line
+interface with::
 
-    docker compose run web bash
-    ./manage.py create-project project_name
-
+    docker compose exec -it web scanpipe COMMAND
 
 .. _offline_installation:
 


### PR DESCRIPTION
and its usages in the Docker context.
Add the /app workdir in the PYTHONPATH env of the Docker file.