### PR TITLE
Add docker tip wrt. pause/unpause

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -20,6 +20,16 @@ ScanCode.io offers several :ref:`built_in_pipelines` depending on your input:
 - Root filesystem
 - ScanCode-toolkit results
 
+Can I pause/resume a running pipeline?
+--------------------------------------
+
+You can stop/terminate a running pipeline but it will not be possible to resume it.
+Although, as a workaround if you run ScanCode.io on desktop or laptop,
+you can pause/unpause the running Docker containers with::
+
+    docker compose pause  # to pause/suspend
+    docker compose unpause  # to unpause/resume
+
 I am unable to run ScanCode.io on Windows?
 ------------------------------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -82,13 +82,6 @@ An overview of the web application usage is available at :ref:`user_interface`.
     For example, if Docker is configured for 8 CPUs, a minimum of 8 GB of memory is
     required.
 
-.. tip::
-    If you run ScanCode.io on desktop or laptop, it may come handy to pause/unpause
-    or suspend your local ScanCode.io system. For this, use these commands::
-
-        docker-compose pause # to pause/suspend
-        docker-compose unpause # to unpause/resume
-
 .. warning::
     To access a dockerized ScanCode.io app from a remote location, the ``ALLOWED_HOSTS``
     and ``CSRF_TRUSTED_ORIGINS`` settings need to be provided in your ``.env`` file,
@@ -101,6 +94,13 @@ An overview of the web application usage is available at :ref:`user_interface`.
     en/dev/ref/settings/#allowed-hosts>`_ and `CSRF_TRUSTED_ORIGINS settings
     <https://docs.djangoproject.com/en/dev/ref/settings/
     #std-setting-CSRF_TRUSTED_ORIGINS>`_ for more details.
+
+.. tip::
+    If you run ScanCode.io on desktop or laptop, it may come handy to pause/unpause
+    or suspend your local ScanCode.io system. For this, use these commands::
+
+        docker compose pause  # to pause/suspend
+        docker compose unpause  # to unpause/resume
 
 Execute a Command
 ^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -82,6 +82,13 @@ An overview of the web application usage is available at :ref:`user_interface`.
     For example, if Docker is configured for 8 CPUs, a minimum of 8 GB of memory is
     required.
 
+.. tip::
+    If you run ScanCode.io on desktop or laptop, it may come handy to pause/unpause
+    or suspend your local ScanCode.io system. For this, use these commands::
+
+        docker-compose pause # to pause/suspend
+        docker-compose unpause # to unpause/resume
+
 .. warning::
     To access a dockerized ScanCode.io app from a remote location, the ``ALLOWED_HOSTS``
     and ``CSRF_TRUSTED_ORIGINS`` settings need to be provided in your ``.env`` file,


### PR DESCRIPTION
This is a tip to inform users that they can
pause and unpause their running ScanCode.io docker installation
