### PR TITLE
Enable setting for per-file timeout #593

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,12 @@ v33.0.0 (unreleased)
   page for each object type.
   https://github.com/nexB/scancode.io/issues/563
 
+- Add setting for per-file timeout. The maximum time allowed for a file to be
+  analyzed when scanning a codebase is configurable with SCANCODEIO_SCAN_FILE_TIMEOUT
+  while the maximum time allowed for a pipeline to complete can be defined using
+  SCANCODEIO_TASK_TIMEOUT.
+  https://github.com/nexB/scancode.io/issues/593
+
 v32.0.1 (2023-02-20)
 --------------------
 

--- a/docs/scancodeio-settings.rst
+++ b/docs/scancodeio-settings.rst
@@ -128,6 +128,30 @@ The following example explicitly defines a timeout value of 60::
 
 .. _scancodeio_settings_pipelines_dirs:
 
+SCANCODEIO_TASK_TIMEOUT
+-----------------------
+
+Maximum time allowed for a pipeline to complete.
+The pipeline run will be stopped and marked as failed if that limit is reached.
+
+The value is a string with specify unit including hour, minute, second
+(e.g. "1h", "3m", "5s")::
+
+    SCANCODEIO_TASK_TIMEOUT=24h
+
+Default: ``24h``
+
+SCANCODEIO_SCAN_FILE_TIMEOUT
+----------------------------
+
+Maximum time allowed for a file to be analyzed when scanning a codebase.
+
+The value unit is second and is defined as an integer::
+
+    SCANCODEIO_SCAN_FILE_TIMEOUT=120
+
+Default: ``120`` (2 minutes)
+
 SCANCODEIO_PIPELINES_DIRS
 -------------------------
 

--- a/scancodeio/settings.py
+++ b/scancodeio/settings.py
@@ -73,8 +73,11 @@ SCANCODEIO_POLICIES_FILE = env.str("SCANCODEIO_POLICIES_FILE", default="policies
 # pipelines directories.
 SCANCODEIO_PIPELINES_DIRS = env.list("SCANCODEIO_PIPELINES_DIRS", default=[])
 
-# Default to 24 hours.
-SCANCODEIO_TASK_TIMEOUT = env.int("SCANCODEIO_TASK_TIMEOUT", default=86400)
+# Maximum time allowed for a pipeline to complete.
+SCANCODEIO_TASK_TIMEOUT = env.str("SCANCODEIO_TASK_TIMEOUT", default="24h")
+
+# Default to 2 minutes.
+SCANCODEIO_SCAN_FILE_TIMEOUT = env.int("SCANCODEIO_SCAN_FILE_TIMEOUT", default=120)
 
 # List views pagination, controls the number of items displayed per page.
 # Syntax in .env: SCANCODEIO_PAGINATE_BY=project=10,project_error=10
@@ -200,6 +203,7 @@ if IS_TESTS:
     # Do not pollute the workspace while running the tests
     SCANCODEIO_WORKSPACE_LOCATION = tempfile.mkdtemp()
     SCANCODEIO_REQUIRE_AUTHENTICATION = True
+    SCANCODEIO_SCAN_FILE_TIMEOUT = 120
 
 # Cache
 


### PR DESCRIPTION
Add setting for per-file timeout. The maximum time allowed for a file to be analyzed when scanning a codebase is configurable with SCANCODEIO_SCAN_FILE_TIMEOUT while the maximum time allowed for a pipeline to complete can be defined using SCANCODEIO_TASK_TIMEOUT.