### PR TITLE
Dark Mode for documentation added

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ author = "nexB Inc."
 extensions = [
     "sphinx.ext.autodoc",
     "sphinxcontrib_django",
+    "sphinx_rtd_dark_mode", #For the Dark Mode
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -72,3 +73,6 @@ html_theme = "sphinx_rtd_theme"
 # html_static_path = ["_static"]
 
 master_doc = "index"
+
+# user starts in light mode (Default Mode)
+default_dark_mode = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,6 +101,7 @@ dev =
     # Documentation
     Sphinx==5.0.2
     sphinx-rtd-theme==1.0.0
+    sphinx-rtd-dark-mode==1.2.4
     sphinxcontrib-django==2.2
     # Release
     bumpver==2022.1120


### PR DESCRIPTION
Added the Dark Mode toggle in the documentation.
Reference - https://github.com/MrDogeBro/sphinx_rtd_dark_mode 

With default Light mode
![Screenshot_2023-04-07_14-18-05](https://user-images.githubusercontent.com/81990329/230578427-81274ad9-fd7c-4134-833c-c51a4f053a13.jpg)

![Screenshot_2023-04-07_14-18-27](https://user-images.githubusercontent.com/81990329/230578572-1e10e273-e544-480e-bffa-b32b66bf6e71.jpg)


Signed-off-by- swastik <swastkk@gmail.com>