### PR TITLE
#210: Project data extendable feature

### DIFF
--- a/scanpipe/templates/scanpipe/base.html
+++ b/scanpipe/templates/scanpipe/base.html
@@ -37,7 +37,7 @@
       .is-black-link {color: #363636;}
       .is-grey-link {color: #7a7a7a;}
       .is-black-link:hover, .is-grey-link:hover {color: #3273dc; text-decoration: underline;}
-      #project-extra-data figure.highlight {max-height: 300px; overflow-y: scroll;}
+      #project-extra-data figure.highlight {max-height: 300px; overflow-y: auto; overflow-x : auto;}
       #project-extra-data pre {background-color: initial; color: initial; padding: initial; white-space: pre-wrap; word-break: break-all;}
       #inputs-panel .panel-block.dropdown:hover {background-color: #f5f5f5;}
       #inputs-panel .dropdown-menu {width: 85%;}

--- a/scanpipe/templates/scanpipe/includes/view_project_data.html
+++ b/scanpipe/templates/scanpipe/includes/view_project_data.html
@@ -1,0 +1,25 @@
+<div id="view-project-data" class="modal">
+    <div class="modal-background"></div>
+    <form method="post">{% csrf_token %}
+      <div class="modal-card">
+        <header class="modal-card-head">
+          <p class="modal-card-title">Project Data</p>
+          <button class="delete" type="button" aria-label="close"></button>
+        </header>
+        <section class="modal-card-body">
+          <div class="field">
+            <div class="control">
+                <div class="panel-block p-0">
+                    <figure class="highlight border-bottom-radius">
+                      <pre class="language-yaml"><code class="p-3">{{ extra_data_yaml }}</code></pre>
+                    </figure>
+                  </div>
+            </div>
+          </div>
+        </section>
+        <footer class="modal-card-foot">
+          <button class="button" type="button">Close</button>
+        </footer>
+      </div>
+    </form>
+  </div>

--- a/scanpipe/templates/scanpipe/project_detail.html
+++ b/scanpipe/templates/scanpipe/project_detail.html
@@ -82,10 +82,11 @@
       </div>
 
       {% if project.extra_data %}
+        {% include "scanpipe/includes/view_project_data.html" %}
         <article id="project-extra-data" class="panel is-info">
-          <p class="panel-heading py-2 is-size-6">
+          <button class="button is-link is-outlined is-fullwidth modal-button panel-heading py-2 is-size-6" data-target="view-project-data" aria-haspopup="true">
             Project data
-          </p>
+          </button>          
           <div class="panel-block p-0">
             <figure class="highlight border-bottom-radius">
               <pre class="language-yaml"><code class="p-3">{{ extra_data_yaml }}</code></pre>


### PR DESCRIPTION
Added feature to:
1. Make project data block extendable.
2. Providing an option to open project data in a modal window by clicking "Project Data" button.

![image](https://user-images.githubusercontent.com/29979533/230721236-36512f61-65fa-411b-8ddc-13d454ba58da.png)
![image](https://user-images.githubusercontent.com/29979533/230721248-2d803d58-dd87-4ba7-9faf-965a2f919db2.png)
