### PR TITLE
Fix logic in update_or_create_package #681

### DIFF
--- a/scanpipe/pipes/__init__.py
+++ b/scanpipe/pipes/__init__.py
@@ -122,11 +122,14 @@ def update_or_create_package(project, package_data, codebase_resource=None):
 
     if package:
         package.update_from_data(package_data)
-    else:
-        if codebase_resource:
+
+    if codebase_resource:
+        if not package:
             package = codebase_resource.create_and_add_package(package_data)
         else:
-            package = DiscoveredPackage.create_from_data(project, package_data)
+            codebase_resource.add_package(package)
+    elif not package:
+        package = DiscoveredPackage.create_from_data(project, package_data)
 
     return package
 

--- a/scanpipe/tests/pipes/test_pipes.py
+++ b/scanpipe/tests/pipes/test_pipes.py
@@ -118,6 +118,13 @@ class ScanPipePipesTest(TestCase):
         self.assertIn(resource1, package2.codebase_resources.all())
         self.assertEqual(datetime.date(2020, 11, 1), package2.release_date)
 
+        # Check to see if we can assign a package to multiple Resources with
+        # update_or_create_package()
+        resource2 = CodebaseResource.objects.create(project=p1, path="filename2.ext")
+        package2 = pipes.update_or_create_package(p1, package_data2, resource2)
+        self.assertIn(package2, resource1.discovered_packages.all())
+        self.assertIn(package2, resource2.discovered_packages.all())
+
     def test_scanpipe_pipes_update_or_create_dependency(self):
         p1 = Project.objects.create(name="Analysis")
         CodebaseResource.objects.create(


### PR DESCRIPTION
This PR updates `update_or_create_package()` to be able to associate an existing Package with a Resource. Previously, if the Package existed and a codebase_resource was passed in, only the Package data was updated and the codebase_resource was not assigned to the Package. 