### PR TITLE
Bump ScanCode toolkit to 31.2.6 #693

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,10 @@ v33.0.0 (unreleased)
 
 - Split the pipes unit tests into their own related submodule.
 
+- Upgrade ScanCode Toolkit to v31.2.6
+  https://github.com/nexB/scancode.io/issues/693
+
+
 v32.1.0 (2023-03-23)
 --------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scancodeio
-version = 32.1.0
+version = 32.1.1
 license = Apache-2.0
 description = Automate software composition analysis pipelines
 long_description = file:README.rst
@@ -71,7 +71,7 @@ install_requires =
     # Docker
     container-inspector==32.0.1
     # ScanCode-toolkit
-    scancode-toolkit[packages]==31.2.4
+    scancode-toolkit[packages]==31.2.6
     extractcode[full]==31.0.0
     commoncode==31.0.2
     # FetchCode


### PR DESCRIPTION
This PR updates SCTK to 31.2.6 to fix #693
Reference: https://github.com/nexB/scancode.io/issues/693