### PR TITLE
Add support for rocky linux in docker scans #757

### DIFF
--- a/scanpipe/pipes/rootfs.py
+++ b/scanpipe/pipes/rootfs.py
@@ -49,6 +49,7 @@ SUPPORTED_DISTROS = [
     "opensuse-tumbleweed",
     "photon",
     "windows",
+    "rocky",
 ]
 
 


### PR DESCRIPTION
Reference: https://github.com/nexB/scancode.io/issues/757