### PR TITLE
Upgrade ScanCode-toolkit to v32.0.5rc3

### DIFF
--- a/scanpipe/tests/data/flume-ng-node-d2d.json
+++ b/scanpipe/tests/data/flume-ng-node-d2d.json
@@ -296,13 +296,7 @@
       "percentage_of_license_text": null,
       "copyrights": [],
       "holders": [],
-      "authors": [
-        {
-          "author": "Apache Maven",
-          "end_line": 1,
-          "start_line": 1
-        }
-      ],
+      "authors": [],
       "package_data": [],
       "for_packages": [],
       "emails": [],

--- a/scanpipe/tests/data/is-npm-1.0.0_scan_package.json
+++ b/scanpipe/tests/data/is-npm-1.0.0_scan_package.json
@@ -154,6 +154,11 @@
       "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
       "license_expression": "mit",
       "detection_count": 2
+    },
+    {
+      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
+      "license_expression": "mit",
+      "detection_count": 1
     }
   ],
   "files": [
@@ -413,7 +418,13 @@
       "percentage_of_license_text": 3.33,
       "copyrights": [],
       "holders": [],
-      "authors": [],
+      "authors": [
+        {
+          "author": "Sindre Sorhus",
+          "start_line": 7,
+          "end_line": 8
+        }
+      ],
       "emails": [
         {
           "email": "sindresorhus@gmail.com",

--- a/scanpipe/tests/data/multiple-is-npm-1.0.0_scan_package.json
+++ b/scanpipe/tests/data/multiple-is-npm-1.0.0_scan_package.json
@@ -248,6 +248,11 @@
       "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
       "license_expression": "mit",
       "detection_count": 4
+    },
+    {
+      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
+      "license_expression": "mit",
+      "detection_count": 2
     }
   ],
   "files": [
@@ -623,7 +628,13 @@
       "percentage_of_license_text": 3.33,
       "copyrights": [],
       "holders": [],
-      "authors": [],
+      "authors": [
+        {
+          "author": "Sindre Sorhus",
+          "start_line": 7,
+          "end_line": 8
+        }
+      ],
       "emails": [
         {
           "email": "sindresorhus@gmail.com",
@@ -876,7 +887,13 @@
       "percentage_of_license_text": 3.33,
       "copyrights": [],
       "holders": [],
-      "authors": [],
+      "authors": [
+        {
+          "author": "Sindre Sorhus",
+          "start_line": 7,
+          "end_line": 8
+        }
+      ],
       "emails": [
         {
           "email": "sindresorhus@gmail.com",

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ install_requires =
     # Docker
     container-inspector==32.0.1
     # ScanCode-toolkit
-    scancode-toolkit[packages]==32.0.4
+    scancode-toolkit[packages]==32.0.5rc3
     extractcode[full]==31.0.0
     commoncode==31.0.2
     # FetchCode


### PR DESCRIPTION
Updates SCTK to v32.0.5rc3 which has the license detection upgrades from https://github.com/nexB/scancode-toolkit/pull/3346