### PR TITLE
Fix the SPDX output to include license texts for LicenseRef #841

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ to be updated for the new ``app`` user, using:
   when generating an XLSX output.
   https://github.com/nexB/scancode.io/issues/824
 
+- Fix the SPDX output to include missing detailed license texts for LicenseRef.
+  https://github.com/nexB/scancode.io/issues/841
+
 v32.4.0 (2023-07-13)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,9 @@ to be updated for the new ``app`` user, using:
   https://github.com/nexB/scancode.io/issues/824
 
 - Fix the SPDX output to include missing detailed license texts for LicenseRef.
+  Add ``licensedb_url`` and ``scancode_url`` to the SPDX ``ExtractedLicensingInfo``
+  ``seeAlsos``.
+  Include the ``Package.notice_text`` as the SPDX ``attribution_texts``.
   https://github.com/nexB/scancode.io/issues/841
 
 v32.4.0 (2023-07-13)

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -2646,6 +2646,10 @@ class DiscoveredPackage(
             if (checksum_value := getattr(self, algorithm))
         ]
 
+        attribution_texts = []
+        if self.notice_text:
+            attribution_texts.append(self.notice_text)
+
         external_refs = []
 
         if package_url := self.package_url:
@@ -2669,6 +2673,7 @@ class DiscoveredPackage(
             filename=self.filename,
             description=self.description,
             release_date=str(self.release_date) if self.release_date else "",
+            attribution_texts=attribution_texts,
             checksums=checksums,
             external_refs=external_refs,
         )

--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -530,28 +530,28 @@ def to_spdx(project, include_files=False):
     """
     output_file = project.get_output_file_path("results", "spdx.json")
 
-    discovereddependencies_qs = get_queryset(project, "discovereddependency")
-    spdx_packages = [
-        *get_queryset(project, "discoveredpackage"),
-        *discovereddependencies_qs,
-    ]
+    discoveredpackage_qs = get_queryset(project, "discoveredpackage")
+    discovereddependency_qs = get_queryset(project, "discovereddependency")
 
     packages_as_spdx = []
     license_expressions = []
-    for spdx_package in spdx_packages:
-        packages_as_spdx.append(spdx_package.as_spdx())
-        if license_expression := getattr(spdx_package, "license_expression", None):
+    relationships = []
+
+    for package in discoveredpackage_qs:
+        packages_as_spdx.append(package.as_spdx())
+        if license_expression := package.declared_license_expression:
             license_expressions.append(license_expression)
 
-    relationships = [
-        spdx.Relationship(
-            spdx_id=dep.spdx_id,
-            related_spdx_id=dep.for_package.spdx_id,
-            relationship="DEPENDENCY_OF",
-        )
-        for dep in discovereddependencies_qs
-        if dep.for_package
-    ]
+    for dependency in discovereddependency_qs:
+        packages_as_spdx.append(dependency.as_spdx())
+        if dependency.for_package:
+            relationships.append(
+                spdx.Relationship(
+                    spdx_id=dependency.spdx_id,
+                    related_spdx_id=dependency.for_package.spdx_id,
+                    relationship="DEPENDENCY_OF",
+                )
+            )
 
     files_as_spdx = []
     if include_files:

--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -482,6 +482,8 @@ def _get_spdx_extracted_licenses(license_expressions):
     licensing = Licensing()
     license_index = get_licenses_by_spdx_key()
     urls_fields = [
+        "licensedb_url",
+        "scancode_url",
         "faq_url",
         "homepage_url",
         "osi_url",

--- a/scanpipe/tests/data/asgiref-3.3.0.spdx.json
+++ b/scanpipe/tests/data/asgiref-3.3.0.spdx.json
@@ -51,6 +51,9 @@
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/asgiref@3.3.0"
         }
+      ],
+      "attributionTexts": [
+        "NOTICE_TEXT"
       ]
     },
     {

--- a/scanpipe/tests/data/asgiref-3.3.0.spdx.json
+++ b/scanpipe/tests/data/asgiref-3.3.0.spdx.json
@@ -29,6 +29,9 @@
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/asgiref@3.3.0"
         }
+      ],
+      "attributionTexts": [
+        "NOTICE_TEXT"
       ]
     },
     {

--- a/scanpipe/tests/data/asgiref-3.3.0_fixtures.json
+++ b/scanpipe/tests/data/asgiref-3.3.0_fixtures.json
@@ -1529,7 +1529,7 @@
     "other_license_expression_spdx": "",
     "other_license_detections": [],
     "extracted_license_statement": "{'license': 'BSD', 'classifiers': ['License :: OSI Approved :: BSD License']}",
-    "notice_text": "",
+    "notice_text": "NOTICE_TEXT",
     "datasource_id": "",
     "file_references": [],
     "parties": [

--- a/scanpipe/tests/data/asgiref-3.3.0_fixtures.json
+++ b/scanpipe/tests/data/asgiref-3.3.0_fixtures.json
@@ -1412,7 +1412,7 @@
     "other_license_expression_spdx": "",
     "other_license_detections": [],
     "extracted_license_statement": "{'license': 'BSD', 'classifiers': ['License :: OSI Approved :: BSD License']}",
-    "notice_text": "",
+    "notice_text": "NOTICE_TEXT",
     "datasource_id": "",
     "file_references": [],
     "parties": [

--- a/scanpipe/tests/data/cyclonedx/asgiref-3.3.0.cdx.json
+++ b/scanpipe/tests/data/cyclonedx/asgiref-3.3.0.cdx.json
@@ -56,6 +56,10 @@
           "value": "https://github.com/django/asgiref/"
         },
         {
+          "name": "aboutcode:notice_text",
+          "value": "NOTICE_TEXT"
+        },
+        {
           "name": "aboutcode:primary_language",
           "value": "Python"
         }

--- a/scanpipe/tests/pipes/test_output.py
+++ b/scanpipe/tests/pipes/test_output.py
@@ -285,9 +285,9 @@ class ScanPipeOutputPipesTest(TestCase):
         self.assertEqual("LicenseRef-scancode-ac3filter", license_infos["licenseId"])
         self.assertEqual("AC3Filter License", license_infos["name"])
         expected = [
+            "https://scancode-licensedb.aboutcode.org/ac3filter",
             "https://github.com/nexB/scancode-toolkit/tree/develop/src/"
             "licensedcode/data/licenses/ac3filter.LICENSE",
-            "https://scancode-licensedb.aboutcode.org/ac3filter",
             "http://www.ac3filter.net/wiki/Download_AC3Filter",
             "http://ac3filter.net",
             "http://ac3filter.net/forum",

--- a/scanpipe/tests/pipes/test_output.py
+++ b/scanpipe/tests/pipes/test_output.py
@@ -285,6 +285,9 @@ class ScanPipeOutputPipesTest(TestCase):
         self.assertEqual("LicenseRef-scancode-ac3filter", license_infos["licenseId"])
         self.assertEqual("AC3Filter License", license_infos["name"])
         expected = [
+            "https://github.com/nexB/scancode-toolkit/tree/develop/src/"
+            "licensedcode/data/licenses/ac3filter.LICENSE",
+            "https://scancode-licensedb.aboutcode.org/ac3filter",
             "http://www.ac3filter.net/wiki/Download_AC3Filter",
             "http://ac3filter.net",
             "http://ac3filter.net/forum",


### PR DESCRIPTION
A side-effect of the `Package.license_expression` to `Package.declared_license_expression` renaming.