### PR TITLE
Modify pipelines to get purls from package_data

### DIFF
--- a/scanpipe/pipelines/populate_purldb.py
+++ b/scanpipe/pipelines/populate_purldb.py
@@ -52,10 +52,13 @@ class PopulatePurlDB(Pipeline):
 
     def populate_purldb_with_detected_purls(self):
         """Add DiscoveredPackage to PurlDB."""
-        if (
-            not self.project.discoveredpackages.exists()
-            and not self.project.discovereddependencies.exists()
-        ):
+        no_packages_and_no_dependencies = all(
+            [
+                not self.project.discoveredpackages.exists(),
+                not self.project.discovereddependencies.exists(),
+            ]
+        )
+        if no_packages_and_no_dependencies:
             packages = scancode.get_packages_with_purl_from_resources(self.project)
             self.feed_purldb(
                 packages=list(packages),

--- a/scanpipe/pipelines/populate_purldb.py
+++ b/scanpipe/pipelines/populate_purldb.py
@@ -52,11 +52,15 @@ class PopulatePurlDB(Pipeline):
 
     def populate_purldb_with_detected_purls(self):
         """Add DiscoveredPackage to PurlDB."""
-        packages = scancode.get_packages_with_purl_from_resources(self.project)
-        self.feed_purldb(
-            packages=list(packages),
-            package_type="DiscoveredPackage",
-        )
+        if (
+            not self.project.discoveredpackages.exists()
+            and not self.project.discovereddependencies.exists()
+        ):
+            packages = scancode.get_packages_with_purl_from_resources(self.project)
+            self.feed_purldb(
+                packages=list(packages),
+                package_type="DiscoveredPackage",
+            )
 
     def feed_purldb(self, packages, package_type):
         """Feed PurlDB with list of PURLs for indexing."""

--- a/scanpipe/pipelines/populate_purldb.py
+++ b/scanpipe/pipelines/populate_purldb.py
@@ -58,6 +58,10 @@ class PopulatePurlDB(Pipeline):
                 not self.project.discovereddependencies.exists(),
             ]
         )
+        # Even when there are no packages/dependencies, resource level
+        # package data could be detected (i.e. when we detect packages,
+        # but skip the assembly step that creates
+        # package/dependency instances)
         if no_packages_and_no_dependencies:
             packages = scancode.get_packages_with_purl_from_resources(self.project)
             self.feed_purldb(

--- a/scanpipe/pipelines/populate_purldb.py
+++ b/scanpipe/pipelines/populate_purldb.py
@@ -22,6 +22,7 @@
 
 from scanpipe.pipelines import Pipeline
 from scanpipe.pipes import purldb
+from scanpipe.pipes import scancode
 
 
 class PopulatePurlDB(Pipeline):
@@ -32,6 +33,7 @@ class PopulatePurlDB(Pipeline):
         return (
             cls.populate_purldb_with_discovered_packages,
             cls.populate_purldb_with_discovered_dependencies,
+            cls.populate_purldb_with_detected_purls,
         )
 
     def populate_purldb_with_discovered_packages(self):
@@ -46,6 +48,14 @@ class PopulatePurlDB(Pipeline):
         self.feed_purldb(
             packages=self.project.discovereddependencies.all(),
             package_type="DiscoveredDependency",
+        )
+
+    def populate_purldb_with_detected_purls(self):
+        """Add DiscoveredPackage to PurlDB."""
+        packages = scancode.get_packages_with_purl_from_resources(self.project)
+        self.feed_purldb(
+            packages=list(packages),
+            package_type="DiscoveredPackage",
         )
 
     def feed_purldb(self, packages, package_type):

--- a/scanpipe/pipelines/populate_purldb.py
+++ b/scanpipe/pipelines/populate_purldb.py
@@ -70,7 +70,7 @@ class PopulatePurlDB(Pipeline):
         if not purldb.is_available():
             raise Exception("PurlDB is not available.")
 
-        package_urls = [package.purl for package in packages]
+        package_urls = list(set([package.purl for package in packages]))
         self.log(f"Populating PurlDB with {len(package_urls):,d} {package_type}")
 
         response = purldb.submit_purls(purls=package_urls)

--- a/scanpipe/pipelines/scan_codebase_packages.py
+++ b/scanpipe/pipelines/scan_codebase_packages.py
@@ -25,7 +25,11 @@ from scanpipe.pipes import scancode
 
 
 class ScanCodebasePackages(ScanCodebase):
-    """Scan a codebase for packages only."""
+    """
+    Scan a codebase for package data only for the purpose of getting
+    all purls (without creating package/dependency instances by
+    package assembly).
+    """
 
     @classmethod
     def steps(cls):

--- a/scanpipe/pipelines/scan_codebase_packages.py
+++ b/scanpipe/pipelines/scan_codebase_packages.py
@@ -40,4 +40,7 @@ class ScanCodebasePackages(ScanCodebase):
 
     def scan_for_application_packages(self):
         """Scan unknown resources for packages information."""
+        # `assemble` is set to False because here in this pipeline we
+        # only detect package_data in resources without creating
+        # Package/Dependency instances, to get all the purls from a codebase.
         scancode.scan_for_application_packages(self.project, assemble=False)

--- a/scanpipe/pipelines/scan_codebase_packages.py
+++ b/scanpipe/pipelines/scan_codebase_packages.py
@@ -21,6 +21,7 @@
 # Visit https://github.com/nexB/scancode.io for support and download.
 
 from scanpipe.pipelines.scan_codebase import ScanCodebase
+from scanpipe.pipes import scancode
 
 
 class ScanCodebasePackages(ScanCodebase):
@@ -36,3 +37,7 @@ class ScanCodebasePackages(ScanCodebase):
             cls.flag_ignored_resources,
             cls.scan_for_application_packages,
         )
+
+    def scan_for_application_packages(self):
+        """Scan unknown resources for packages information."""
+        scancode.scan_for_application_packages(self.project, assemble=False)

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -450,15 +450,14 @@ def get_packages_with_purl_from_resources(project):
     """
     for resource in project.codebaseresources.has_package_data():
         for package_mapping in resource.package_data:
-            for dep in package_mapping.get("dependencies"):
+            for dependency in package_mapping.get("dependencies"):
                 yield packagedcode_models.Dependency.from_dependent_package(
-                    dependent_package=dep,
+                    dependent_package=dependency,
                     datafile_path=resource.path,
                     datasource_id=package_mapping.get("datasource_id"),
                     package_uid=None,
                 )
-            pd = packagedcode_models.PackageData.from_dict(mapping=package_mapping)
-            yield pd
+            yield packagedcode_models.PackageData.from_dict(mapping=package_mapping)
 
 
 def get_pretty_params(args):

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -340,9 +340,14 @@ def scan_for_files(project, resource_qs=None):
 
 def scan_for_application_packages(project, assemble=True):
     """
-    Run a package scan on files without a status for a `project`,
-    then create DiscoveredPackage and DiscoveredDependency instances
-    from the detected package data
+    Run a package scan on resources without a status for a `project`,
+    and add them in their respective `package_data` attribute.
+    Then create DiscoveredPackage and DiscoveredDependency instances
+    from the detected package data optionally. If the `assemble` argument
+    is set to `True`, DiscoveredPackage and DiscoveredDependency instances
+    are created and added to the project by assembling resource level
+    package_data, and resources which belong in the DiscoveredPackage
+    instance, are assigned to that package.
 
     Multiprocessing is enabled by default on this pipe, the number of processes can be
     controlled through the SCANCODEIO_PROCESSES setting.
@@ -432,6 +437,11 @@ def assemble_packages(project):
 
 
 def get_packages_with_purl_from_resources(project):
+    """
+    Yield Dependency or PackageData objects created from detected package_data
+    in all the project resources. Both Dependency and PackageData objects have
+    the `purl` attribute with a valid purl.
+    """
     for resource in project.codebaseresources.has_package_data():
         for package_mapping in resource.package_data:
             for dep in package_mapping.get("dependencies"):

--- a/scanpipe/tests/pipes/test_scancode.py
+++ b/scanpipe/tests/pipes/test_scancode.py
@@ -396,6 +396,23 @@ class ScanPipeScancodePipesTest(TestCase):
         self.assertEqual(1, DiscoveredPackage.objects.count())
         self.assertEqual(1, DiscoveredDependency.objects.count())
 
+    def test_scanpipe_pipes_scancode_get_packages_with_purl_from_resources(self):
+        project = Project.objects.create(name="Analysis")
+        filename = "package_assembly_codebase.json"
+        project_scan_location = self.data_location / "scancode" / filename
+        input.load_inventory_from_toolkit_scan(project, project_scan_location)
+
+        project.discoveredpackages.all().delete()
+        self.assertEqual(0, project.discoveredpackages.count())
+
+        packages = list(scancode.get_packages_with_purl_from_resources(project))
+
+        package_purl_exists = [True for package in packages if package.purl]
+        package_purls = [package.purl for package in packages]
+        self.assertTrue(package_purl_exists)
+        self.assertEqual(len(package_purl_exists), 1)
+        self.assertTrue("pkg:npm/test@0.1.0" in package_purls)
+
     def test_scanpipe_pipes_scancode_run_scancode(self):
         project = Project.objects.create(name="name with space")
         output = scancode.run_scan(

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -445,6 +445,24 @@ class PipelinesIntegrationTest(TestCase):
         expected_file = self.data_location / "is-npm-1.0.0_scan_codebase.json"
         self.assertPipelineResultEqual(expected_file, result_file)
 
+    def test_scanpipe_scan_codebase_packages_does_not_create_packages(self):
+        pipeline_name = "scan_codebase_packages"
+        project1 = Project.objects.create(name="Analysis")
+
+        filename = "is-npm-1.0.0.tgz"
+        input_location = self.data_location / filename
+        project1.copy_input_from(input_location)
+
+        run = project1.add_pipeline(pipeline_name)
+        pipeline = run.make_pipeline_instance()
+
+        exitcode, out = pipeline.execute()
+        self.assertEqual(0, exitcode, msg=out)
+
+        self.assertEqual(6, project1.codebaseresources.count())
+        self.assertEqual(0, project1.discoveredpackages.count())
+        self.assertEqual(0, project1.discovereddependencies.count())
+
     def test_scanpipe_scan_codebase_can_process_wheel(self):
         pipeline_name = "scan_codebase"
         project1 = Project.objects.create(name="Analysis")

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -974,9 +974,9 @@ class PipelinesIntegrationTest(TestCase):
         exitcode, out = pipeline.execute()
         self.assertEqual(0, exitcode, msg=out)
 
-        self.assertIn("Populating PurlDB with 2 DiscoveredPackage", run.log)
-        self.assertIn("Successfully queued 2 PURLs for indexing in PurlDB", run.log)
+        self.assertIn("Populating PurlDB with 1 DiscoveredPackage", run.log)
+        self.assertIn("Successfully queued 1 PURLs for indexing in PurlDB", run.log)
         self.assertIn("1 PURLs were already present in PurlDB index queue", run.log)
         self.assertIn("Couldn't index 1 unsupported PURLs", run.log)
-        self.assertIn("Populating PurlDB with 4 DiscoveredDependency", run.log)
-        self.assertIn("Successfully queued 4 PURLs for indexing in PurlDB", run.log)
+        self.assertIn("Populating PurlDB with 2 DiscoveredDependency", run.log)
+        self.assertIn("Successfully queued 2 PURLs for indexing in PurlDB", run.log)


### PR DESCRIPTION
The `scan_codebase_packages` pipeline currently takes a lot of time for large projects with ~700k resources, and it is stuck in the `scan_for_application_packages` step, and so presumably it's the package assembly in there that takes the longest.
The main objective of this pipeline was as a precursor to the `populate_purldb` pipeline to get purls from the codebase and submit them to purldb for indexing. So this PR does the following:

1. Disables the package assembly for the `scan_codebase_packages` pipeline. So we only have the codebase scanned for package_data and these are added to the specific resources without creating DiscoveredPackage and DiscoveredDependency objects out of these package data, by assembling.
2. If there are no packages/dependencies added to the project (otherwise we will add purls from these packages/deps twice), then further look for package data detected in the resources and add purls from those.