### PR TITLE
D2d pipeline updates

### DIFF
--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -1674,12 +1674,15 @@ class CodebaseResourceQuerySet(ProjectRelatedQuerySet):
             return self.filter(status=status)
         return self.filter(~Q(status=""))
 
-    def not_status(self, status=None):
+    def no_status(self, status=None):
+        """
+        Filter for CodebaseResources without a status.
+
+        If `status` is provided, then we filter for CodebaseResources whose
+        status is not equal to `status`.
+        """
         if status:
             return self.filter(~Q(status=status))
-        return self.filter(status="")
-
-    def no_status(self):
         return self.filter(status="")
 
     def empty(self):
@@ -1763,20 +1766,6 @@ class CodebaseResourceQuerySet(ProjectRelatedQuerySet):
             ~Q(extra_data__directory_content="")
             and ~Q(extra_data__directory_content__in=IGNORED_DIRECTORY_FINGERPRINTS)
         )
-
-    def paginated(self, per_page=5000):
-        """
-        Iterate over a (large) QuerySet by chunks of ``per_page`` items.
-
-        This is done to prevent high memory usage when using a regular QuerySet
-        or QuerySet.iterator to iterate over a large number of
-        CodebaseResources:
-
-        https://nextlinklabs.com/resources/insights/django-big-data-iteration
-        https://stackoverflow.com/questions/4222176/why-is-iterating-through-a-large-django-queryset-consuming-massive-amounts-of-me/
-        """
-        for page in Paginator(self, per_page=per_page):
-            yield page.object_list
 
 
 class ScanFieldsModelMixin(models.Model):

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -38,7 +38,6 @@ from django.conf import settings
 from django.core import checks
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
-from django.core.paginator import Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import EMPTY_VALUES
 from django.db import models

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -1674,6 +1674,11 @@ class CodebaseResourceQuerySet(ProjectRelatedQuerySet):
             return self.filter(status=status)
         return self.filter(~Q(status=""))
 
+    def not_status(self, status=None):
+        if status:
+            return self.filter(~Q(status=status))
+        return self.filter(status="")
+
     def no_status(self):
         return self.filter(status="")
 

--- a/scanpipe/pipelines/deploy_to_develop.py
+++ b/scanpipe/pipelines/deploy_to_develop.py
@@ -56,6 +56,7 @@ class DeployToDevelop(Pipeline):
             cls.map_java_to_class,
             cls.map_jar_to_source,
             cls.map_javascript,
+            cls.match_directories_to_purldb,
             cls.match_resources_to_purldb,
             cls.map_javascript_post_purldb_match,
             cls.map_javascript_path,
@@ -162,8 +163,8 @@ class DeployToDevelop(Pipeline):
         """
         d2d.map_javascript(project=self.project, logger=self.log)
 
-    def match_resources_to_purldb(self):
-        """Match selected files by extension and directories in PurlDB."""
+    def match_directories_to_purldb(self):
+        """Match selected directories in PurlDB."""
         if not purldb.is_available():
             self.log("PurlDB is not available. Skipping.")
             return
@@ -172,6 +173,12 @@ class DeployToDevelop(Pipeline):
             project=self.project,
             logger=self.log,
         )
+
+    def match_resources_to_purldb(self):
+        """Match selected files by extension in PurlDB."""
+        if not purldb.is_available():
+            self.log("PurlDB is not available. Skipping.")
+            return
 
         d2d.match_purldb_resources(
             project=self.project,

--- a/scanpipe/pipelines/deploy_to_develop.py
+++ b/scanpipe/pipelines/deploy_to_develop.py
@@ -51,11 +51,12 @@ class DeployToDevelop(Pipeline):
             cls.flag_ignored_resources,
             cls.map_about_files,
             cls.map_checksum,
+            cls.match_archives_to_purldb,
             cls.find_java_packages,
             cls.map_java_to_class,
             cls.map_jar_to_source,
             cls.map_javascript,
-            cls.match_purldb,
+            cls.match_resources_to_purldb,
             cls.map_javascript_post_purldb_match,
             cls.map_javascript_path,
             cls.map_javascript_colocation,
@@ -129,6 +130,19 @@ class DeployToDevelop(Pipeline):
         """Map using SHA1 checksum."""
         d2d.map_checksum(project=self.project, checksum_field="sha1", logger=self.log)
 
+    def match_archives_to_purldb(self):
+        """Match selected package archives by extension to PurlDB."""
+        if not purldb.is_available():
+            self.log("PurlDB is not available. Skipping.")
+            return
+
+        d2d.match_purldb_resources(
+            project=self.project,
+            extensions=self.purldb_package_extensions,
+            matcher_func=d2d.match_purldb_package,
+            logger=self.log,
+        )
+
     def find_java_packages(self):
         """Find the java package of the .java source files."""
         d2d.find_java_packages(self.project, logger=self.log)
@@ -148,18 +162,11 @@ class DeployToDevelop(Pipeline):
         """
         d2d.map_javascript(project=self.project, logger=self.log)
 
-    def match_purldb(self):
+    def match_resources_to_purldb(self):
         """Match selected files by extension and directories in PurlDB."""
         if not purldb.is_available():
             self.log("PurlDB is not available. Skipping.")
             return
-
-        d2d.match_purldb_resources(
-            project=self.project,
-            extensions=self.purldb_package_extensions,
-            matcher_func=d2d.match_purldb_package,
-            logger=self.log,
-        )
 
         d2d.match_purldb_directories(
             project=self.project,

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -617,6 +617,7 @@ def match_purldb_resources(
         project=project,
         to_resources=to_resources,
         matcher_func=matcher_func,
+        chunk_size=chunk_size,
         logger=logger,
     )
 

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -561,7 +561,9 @@ def match_purldb_directory(project, resource):
             return create_package_from_purldb_data(project, [resource], package_data)
 
 
-def match_sha1s_to_purldb(project, resources_by_sha1, matcher_func, package_data_by_purldb_urls):
+def match_sha1s_to_purldb(
+    project, resources_by_sha1, matcher_func, package_data_by_purldb_urls
+):
     """
     Process `resources_by_sha1` with `matcher_func` and return a 3-tuple
     contaning an empty defaultdict(list), the number of matches and the number

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -594,7 +594,7 @@ def match_purldb_resources(
     to_resources = (
         project.codebaseresources.files()
         .to_codebase()
-        .no_status()
+        .not_status(status=flag.ABOUT_MAPPED)
         .has_value("sha1")
         .filter(extension__in=extensions)
     )

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -594,7 +594,7 @@ def match_purldb_resources(
     to_resources = (
         project.codebaseresources.files()
         .to_codebase()
-        .not_status(status=flag.ABOUT_MAPPED)
+        .no_status()
         .has_value("sha1")
         .filter(extension__in=extensions)
     )
@@ -625,7 +625,7 @@ def _match_purldb_resources(
     project, to_resources, matcher_func, chunk_size=1000, logger=None
 ):
     resource_count = to_resources.count()
-    resource_iterator = to_resources.iterator()
+    resource_iterator = to_resources.iterator(chunk_size=chunk_size)
     progress = LoopProgress(resource_count, logger)
     total_matched_count = 0
     total_sha1_count = 0

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -561,7 +561,27 @@ def match_purldb_directory(project, resource):
             return create_package_from_purldb_data(project, [resource], package_data)
 
 
-def match_purldb_resources(project, extensions, matcher_func, logger=None):
+def match_sha1s_to_purldb(project, resources_by_sha1, matcher_func, package_data_by_purldb_urls):
+    """
+    Process `resources_by_sha1` with `matcher_func` and return a 3-tuple
+    contaning an empty defaultdict(list), the number of matches and the number
+    of sha1s sent to purldb.
+    """
+    matched_count = matcher_func(
+        project=project,
+        resources_by_sha1=resources_by_sha1,
+        package_data_by_purldb_urls=package_data_by_purldb_urls,
+    )
+    sha1_count = len(resources_by_sha1)
+    # Clear out resources_by_sha1 when we are done with the current batch of
+    # CodebaseResources
+    resources_by_sha1 = defaultdict(list)
+    return resources_by_sha1, matched_count, sha1_count
+
+
+def match_purldb_resources(
+    project, extensions, matcher_func, chunk_size=1000, logger=None
+):
     """
     Match against PurlDB selecting codebase resources using provided
     ``package_extensions`` for archive type files, and ``resource_extensions``.
@@ -603,35 +623,44 @@ def _match_purldb_resources(
     project, to_resources, matcher_func, chunk_size=1000, logger=None
 ):
     resource_count = to_resources.count()
-    resource_iterator = to_resources.paginated(per_page=chunk_size)
+    resource_iterator = to_resources.iterator()
     progress = LoopProgress(resource_count, logger)
-    matched_count = 0
-    sha1_count = 0
+    total_matched_count = 0
+    total_sha1_count = 0
+    processed_resources_count = 0
     resources_by_sha1 = defaultdict(list)
     package_data_by_purldb_urls = {}
 
-    for resources_batch in resource_iterator:
-        for to_resource in progress.iter(resources_batch):
-            resources_by_sha1[to_resource.sha1].append(to_resource)
-            if to_resource.path.endswith(".map"):
-                for js_sha1 in js.source_content_sha1_list(to_resource):
-                    resources_by_sha1[js_sha1].append(to_resource)
+    for to_resource in progress.iter(resource_iterator):
+        resources_by_sha1[to_resource.sha1].append(to_resource)
+        if to_resource.path.endswith(".map"):
+            for js_sha1 in js.source_content_sha1_list(to_resource):
+                resources_by_sha1[js_sha1].append(to_resource)
+        processed_resources_count += 1
 
-        matched_count += matcher_func(
+        if processed_resources_count % chunk_size == 0:
+            resources_by_sha1, matched_count, sha1_count = match_sha1s_to_purldb(
+                project=project,
+                resources_by_sha1=resources_by_sha1,
+                matcher_func=matcher_func,
+                package_data_by_purldb_urls=package_data_by_purldb_urls,
+            )
+            total_matched_count += matched_count
+            total_sha1_count += sha1_count
+
+    if resources_by_sha1:
+        resources_by_sha1, matched_count, sha1_count = match_sha1s_to_purldb(
             project=project,
             resources_by_sha1=resources_by_sha1,
+            matcher_func=matcher_func,
             package_data_by_purldb_urls=package_data_by_purldb_urls,
         )
-
-        # Keep track of the total number of SHA1s we send
-        sha1_count += len(resources_by_sha1)
-        # Clear out resources_by_sha1 when we are done with the current batch of
-        # CodebaseResources
-        resources_by_sha1 = defaultdict(list)
+        total_matched_count += matched_count
+        total_sha1_count += sha1_count
 
     logger(
-        f"{matched_count:,d} resources matched in PurlDB "
-        f"using {sha1_count:,d} SHA1s"
+        f"{total_matched_count:,d} resources matched in PurlDB "
+        f"using {total_sha1_count:,d} SHA1s"
     )
 
 


### PR DESCRIPTION
This PR contains changes to the D2D pipeline and the purldb matching step.

There is workaround for #929, where we process `to_resources` using `.iterator()` instead of `.paginated()`. We now keep track of the number of to/ resources we're iterating through, so we can send off a match requests of `chunk_size`. After we iterate through `to_resources`, if `resources_by_sha1` has sha1s and Resources remaining, we send those sha1s off to be matched.

The `match_purldb` step in the D2D pipeline has now been split up into two steps, `match_archives_to_purldb` and `match_resources_to_purldb`.