### PR TITLE
webhook subscription target URLs: Add textarea in project settings view

### DIFF
--- a/scanpipe/pipes/post.py
+++ b/scanpipe/pipes/post.py
@@ -1,0 +1,32 @@
+import json
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+import requests
+
+
+def test_json_post_accepting_urls(urls=[]):
+    if not urls:
+        return []
+    # define test payload
+    payload = {"name": "test"}
+    errors = []
+    if isinstance(urls, str):
+        urls = [url.strip() for url in urls.split()]
+
+    for url in urls:
+        if not url:
+            continue
+        try:
+            response = requests.post(
+                url=url,
+                data=json.dumps(payload, cls=DjangoJSONEncoder),
+                headers={"Content-Type": "application/json"},
+                timeout=10,
+            )
+            # Raise an HTTPError for bad responses (4xx or 5xx)
+            response.raise_for_status()
+        except requests.exceptions.RequestException:
+            errors.append(url)
+
+    return errors

--- a/scanpipe/templates/scanpipe/includes/project_settings_menu.html
+++ b/scanpipe/templates/scanpipe/includes/project_settings_menu.html
@@ -25,6 +25,11 @@
         <i class="fa-solid fa-file-lines mr-2"></i>Attribution
       </a>
     </li>
+    <li>
+      <a href="#webhooksubscriptions">
+        <i class="fa-solid fa-file-lines mr-2"></i>Webhook Subscriptions
+      </a>
+    </li>
   </ul>
   <hr class="my-4">
   <p class="menu-label">

--- a/scanpipe/templates/scanpipe/project_settings.html
+++ b/scanpipe/templates/scanpipe/project_settings.html
@@ -108,6 +108,21 @@
               </div>
             </div>
 
+            <div class="panel">
+              <p id="webhooksubscriptions" class="panel-heading py-2 is-size-6">Webhook Subscriptions</p>
+              <div class="panel-block is-block px-4">
+                <div class="field">
+                  <label class="label" for="{{ form.webhooksubscriptions.id_for_label }}">
+                    {{ form.webhooksubscriptions.label }}
+                  </label>
+                  <div class="control">
+                    {{ form.webhooksubscriptions }}
+                  </div>
+                  <p class="help">{{ form.webhooksubscriptions.help_text }}</p>
+                </div>
+              </div>
+            </div>
+
             <div class="columns mt-4 mb-5 is-variable is-1">
               <div class="column is-one-third">
                 <a href="{% url 'project_detail' project.slug %}" class="button is-fullwidth">Cancel</a>


### PR DESCRIPTION
webhooksubscriptions: Add textarea input for target URLs

- Create a new form obj `WebhookSubscriptionArea` 
- Include `WebhookSubscriptionArea` in `ProjectSettingsForm`
- Initial value is "\n" separated list of URLs retrieved using `project.websubscriptions.all()`
- While submitting form
  - Check if `websubscriptions` input already is not `None` or `""`
  - Delete all existing `WebhookSubscription` objects for the project
  - Create new `WebhookSubscription` objects for each URL in the input
  - Delete `webhooksubscriptions` key from `config` dict to avoid saving it in `settings` model

UI updates

https://github.com/nexB/scancode.io/assets/64846852/5bd1c392-49fb-40f6-a45e-3ffa914b1e9c



Fixes: #1027
