### PR TITLE
Bump matchcode-toolkit to 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ install_requires =
     # Font Awesome
     fontawesomefree==6.5.1
     # MatchCode-toolkit
-    matchcode-toolkit==1.1.3
+    matchcode-toolkit==2.0.0
     # Univers
     univers==30.11.0
 


### PR DESCRIPTION
This PR updates matchcode-toolkit to 2.0.0 to address issues from https://github.com/nexB/purldb/issues/263