### PR TITLE
Bump matchcode-toolkit to 2.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ install_requires =
     # Font Awesome
     fontawesomefree==6.5.1
     # MatchCode-toolkit
-    matchcode-toolkit==2.0.0
+    matchcode-toolkit==2.0.1
     # Univers
     univers==30.11.0
 


### PR DESCRIPTION
This PR updates matchcode-toolkit to 2.0.1, following updates to the ScanAndFingerprintPackage pipleline.