### PR TITLE
ui/breadcrumb: Ensure the 3rd level of breadcrumb link reflects the current relative URL

### DIFF
--- a/scanpipe/templates/scanpipe/includes/breadcrumb.html
+++ b/scanpipe/templates/scanpipe/includes/breadcrumb.html
@@ -8,10 +8,24 @@
         <li><a href="{{ project.get_absolute_url }}" class="has-text-grey">{{ project.name }}</a></li>
       {% endif %}
       {% if current %}
-        <li class="is-active"><a href="#" aria-current="page">{{ current }}</a></li>
+        <li>
+          <a id="current-page-link" href="#"  class="has-text-black-bis">
+            {{ current }}
+          </a>
+        </li>
       {% else %}
         <li class="is-active"><a href="#" aria-current="page">{{ project.name }}</a></li>
       {% endif %}
     {% endif %}
   </ul>
 </nav>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    // Get the current relative URL using JavaScript
+    var currentRelativeUrl = window.location.pathname;
+
+    // Set the href attribute of the link to the current relative URL
+    document.getElementById('current-page-link').href = currentRelativeUrl;
+  });
+</script>


### PR DESCRIPTION
- The included JavaScript in breadcrumb.html now updates the href attribute of the link with id "current-page-link" to match the current relative URL.

Fixes: #981

UI Preview:

https://github.com/nexB/scancode.io/assets/64846852/e01635e7-5ab0-41a0-b76e-808047ea2c62

