### PR TITLE
Removed extra line from package copyright section

### DIFF
--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -1233,7 +1233,7 @@ def create_local_files_packages(project):
         defaults = {
             "declared_license_expression": group.get("detected_license_expression"),
             # The Counter is used to sort by most frequent values.
-            "copyright": "\n\n".join(Counter(copyrights).keys()),
+            "copyright": "\n".join(Counter(copyrights).keys()),
         }
         pipes.create_local_files_package(project, defaults, codebase_resource_ids)
 


### PR DESCRIPTION
Reference #1010 

earlier the copyright section had two line spaces which were consuming extra space I have removed the extra spaces.

Copyright 1997-2007 Sun Microsystems, Inc.

Copyright 2000-2007 Sun Microsystems, Inc.

Copyright 2003-2009 Sun Microsystems, Inc.

Copyright 2003-20… 

