### PR TITLE
Removed extra spaces from package copyright section.

### DIFF
--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -1233,7 +1233,7 @@ def create_local_files_packages(project):
         defaults = {
             "declared_license_expression": group.get("detected_license_expression"),
             # The Counter is used to sort by most frequent values.
-            "copyright": "\n\n".join(Counter(copyrights).keys()),
+            "copyright": "\n".join(Counter(copyrights).keys()),
         }
         pipes.create_local_files_package(project, defaults, codebase_resource_ids)
 

--- a/scanpipe/tests/pipes/test_d2d.py
+++ b/scanpipe/tests/pipes/test_d2d.py
@@ -1006,7 +1006,7 @@ class ScanPipeD2DPipesTest(TestCase):
         self.assertEqual("local-files", package.type)
         self.assertEqual(self.project1.slug, package.namespace)
         self.assertEqual("mit", package.declared_license_expression)
-        self.assertEqual("Copyright 2023\n\nCopyright 1984", package.copyright)
+        self.assertEqual("Copyright 2023\nCopyright 1984", package.copyright)
 
     @mock.patch("scanpipe.pipes.d2d._match_purldb_resources")
     def test_match_resources_with_no_java_source(self, mock_match_purldb_resources):


### PR DESCRIPTION
reference-> #1010

As mentioned in the issue , the copyright section has extra space which was taking too much space so I removed the extra spaces