### PR TITLE
Use new /collect/index_packages/ endpoint to populate PurlDB

### DIFF
--- a/scanpipe/pipes/purldb.py
+++ b/scanpipe/pipes/purldb.py
@@ -196,7 +196,7 @@ def submit_purls(packages, timeout=DEFAULT_TIMEOUT, api_url=PURLDB_API_URL):
     data = json.dumps(payload)
 
     response = request_post(
-        url=f"{api_url}packages/index_packages/",
+        url=f"{api_url}collect/index_packages/",
         data=data,
         timeout=timeout,
         headers=headers,


### PR DESCRIPTION
We have reorganized the endpoint for collecting data on the PurlDB side. Going forward, we should use `/api/collect/index_packages/` for bulk `indexing` and `reindexing` of packages.
For more details, see https://github.com/nexB/purldb/issues/223.