### PR TITLE
[Improve UI]- Remove the relative dates

### DIFF
--- a/scanpipe/templates/scanpipe/includes/project_list_table.html
+++ b/scanpipe/templates/scanpipe/includes/project_list_table.html
@@ -12,7 +12,7 @@
         <div>
           {% include 'scanpipe/includes/project_labels.html' with labels=project.labels.all only %}
         </div>
-        <span class="has-text-grey is-size-7 is-block" title="{{ project.created_date|date:'N j, Y, P T' }}">Created {{ project.created_date|naturaltime }}</span>
+        <span class="has-text-grey is-size-7 is-block" title="{{ project.created_date|naturaltime }}">Created {{ project.created_date|date:'Y-m-d H:i'  }}</span>
       </th>
       <td>
         {% if project.discoveredpackages_count %}

--- a/scanpipe/templates/scanpipe/project_detail.html
+++ b/scanpipe/templates/scanpipe/project_detail.html
@@ -26,9 +26,8 @@
         </nav>
         <div class="subtitle is-size-6">
           <span class="has-text-grey">
-            <span title="{{ project.created_date|date:'N j, Y, P T' }}">
-              Created {{ project.created_date|naturaltime }}
-            </span>
+            <span title="{{ project.created_date|naturaltime }}">
+              Created {{ project.created_date|date:'Y-m-d H:i' }}</span>
           </span>
           {% include 'scanpipe/includes/project_labels.html' with labels=labels only %}
           <a class="modal-button is-size-7" data-target="add-labels-modal" aria-haspopup="true">


### PR DESCRIPTION
In reference to https://github.com/nexB/scancode.io/issues/990 & https://github.com/nexB/scancode.io/issues/942
Changed the dates to standard ISO data format as YYYY-MM-DD HH:MM in `project_details.html` & 'project_list_table.html' and relative dates on the hover effect.

Screenshots attached

![Screenshot from 2024-03-06 02-45-49](https://github.com/nexB/scancode.io/assets/81990329/26c44678-72df-4890-932e-8143542ae821)

![Screenshot from 2024-03-06 02-46-11](https://github.com/nexB/scancode.io/assets/81990329/26db6c04-b4df-4186-8c06-285212f0797e)
