### PR TITLE
fix Cannot copy path to input URL in project #1120  

### DIFF
--- a/scanpipe/templates/scanpipe/panels/project_inputs.html
+++ b/scanpipe/templates/scanpipe/panels/project_inputs.html
@@ -29,7 +29,7 @@
         {% if input_source.filename %}
           {{ input_source.filename }}
         {% else %}
-          {{ input_source.download_url }}
+          <a href="{{ input_source.download_url }}" title="{{ input_source.download_url }}">{{ input_source.download_url }}</a>
         {% endif %}
       </div>
       <div class="is-flex is-size-7">


### PR DESCRIPTION
This PR fixes #1120

Intially the input URL was not clickable and easy to copy.
![image](https://github.com/nexB/scancode.io/assets/103296906/aadaf95b-ca2e-4bf4-bd2e-aa2eda085235)


Now, I have changed the input URL to a hyperlink so when clicked it will open the URL and can be copied easily.
![image](https://github.com/nexB/scancode.io/assets/103296906/47981778-4669-4f55-a0e4-29814ef8c8e9)




please let me know if this solution works fine or not. Thanks.