### PR TITLE
Add mariner to supported distros

### DIFF
--- a/scanpipe/pipes/rootfs.py
+++ b/scanpipe/pipes/rootfs.py
@@ -47,6 +47,7 @@ SUPPORTED_DISTROS = [
     "fedora",
     "sles",
     "opensuse",
+    "mariner",
     "opensuse-tumbleweed",
     "photon",
     "windows",


### PR DESCRIPTION
Reference: https://github.com/nexB/scancode-toolkit/pull/3734
Reference: https://github.com/nexB/scancode.io/issues/1156