### PR TITLE
Bump matchcode-toolkit to v5.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ v34.5.0 (unreleased)
 - Add value validation for the search complex query syntax.
   https://github.com/nexB/scancode.io/issues/1183
 
+- Bump matchcode-toolkit version to v5.0.0.
+
 v34.4.0 (2024-04-22)
 --------------------
 

--- a/scanpipe/tests/pipes/test_matchcode.py
+++ b/scanpipe/tests/pipes/test_matchcode.py
@@ -330,6 +330,6 @@ class MatchCodePipesTest(TestCase):
         codebase_resource1.refresh_from_db()
         codebase_resource2.refresh_from_db()
 
-        expected_extra_data = {"halo1": "ef420f7e84c8c74c691315f0a06ac4f0"}
+        expected_extra_data = {"halo1": "000000b8ef420f7e84c8c74c691315f0a06ac4f0"}
         self.assertEqual(expected_extra_data, codebase_resource1.extra_data)
         self.assertFalse(codebase_resource2.extra_data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ install_requires =
     # Font Awesome
     fontawesomefree==6.5.1
     # MatchCode-toolkit
-    matchcode-toolkit==4.1.0
+    matchcode-toolkit==5.0.0
     # Univers
     univers==30.11.0
     # Markdown


### PR DESCRIPTION
This PR updates matchcode-toolkit to v5.0.0 in order to use the updated file fingerprinting function.