### PR TITLE
Bump matchcode-toolkit version to v5.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ install_requires =
     # Font Awesome
     fontawesomefree==6.5.1
     # MatchCode-toolkit
-    matchcode-toolkit==5.0.0
+    matchcode-toolkit==5.1.0
     # Univers
     univers==30.11.0
     # Markdown


### PR DESCRIPTION
This PR bumps the matchcode-toolkit version to v5.1.0. The changes in v5.1.0 are in the scancode-toolkit fingerprinting plugin, where file fingerprints are now computed for text files. We are bumping the version here so purldb can install scancode.io as a dependency and not have issues with conflicting matchcode-toolkit version requirements. 