### PR TITLE
Bump container-inspector and commoncode versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,11 +70,11 @@ install_requires =
     # WSGI server
     gunicorn==22.0.0
     # Docker
-    container-inspector==32.0.1
+    container-inspector==33.0.0
     # ScanCode-toolkit
     scancode-toolkit[packages]==32.1.0
     extractcode[full]==31.0.0
-    commoncode==31.0.3
+    commoncode==31.2.1
     # FetchCode
     fetchcode-container==1.2.3.210512; sys_platform == "linux"
     # Inspectors


### PR DESCRIPTION
This PR updates container-inspector to v33.0.0 and commoncode to v31.2.1 . The main change in these two dependencies is that the `container_inspector.distro.parse_os_release` function has been moved to `commoncode.distro.parse_os_release`.