### PR TITLE
Do not sys.exit in execute_project function

### DIFF
--- a/scanpipe/management/commands/__init__.py
+++ b/scanpipe/management/commands/__init__.py
@@ -396,7 +396,7 @@ def execute_project(project, run_async=False, command=None):  # noqa: C901
         if verbosity > 0:
             msg = f"{run.pipeline_name} added to the tasks queue for execution."
             command.stdout.write(msg, command.style.SUCCESS)
-        sys.exit(0)
+        return
 
     if verbosity > 0:
         command.stdout.write(f"Start the {run.pipeline_name} pipeline execution...")

--- a/scanpipe/management/commands/__init__.py
+++ b/scanpipe/management/commands/__init__.py
@@ -21,7 +21,6 @@
 # Visit https://github.com/nexB/scancode.io for support and download.
 
 import shutil
-import sys
 import traceback
 from pathlib import Path
 


### PR DESCRIPTION
In order to support running this function in loop such as the PurlDB worker.