### PR TITLE
Fix an issue in the d2d JavaScript mapper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ v34.6.3 (unreleased)
   for fetching Docker images using skopeo through ``run_command_safely`` calls.
   https://github.com/nexB/scancode.io/issues/1257
 
+- Fix an issue in the d2d JavaScript mapper.
+  https://github.com/nexB/scancode.io/pull/1274
+
 v34.6.2 (2024-06-18)
 --------------------
 

--- a/scanpipe/pipelines/scan_single_package.py
+++ b/scanpipe/pipelines/scan_single_package.py
@@ -120,7 +120,7 @@ class ScanSinglePackage(Pipeline):
             self.project.add_error(
                 description="\n".join(errors),
                 model=self.pipeline_name,
-                details={"path": resource_path},
+                details={"resource_path": resource_path.removeprefix("codebase/")},
             )
 
         if not scan_output_path.exists():

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -965,7 +965,7 @@ class AboutFileIndexes:
 
             if not mapped_resources:
                 error_message_details = {
-                    "path": about_path,
+                    "resource_path": about_path,
                     "package_data": package_data,
                 }
                 project.add_warning(

--- a/scanpipe/pipes/js.py
+++ b/scanpipe/pipes/js.py
@@ -192,7 +192,7 @@ def get_minified_resource(map_resource, minified_resources):
     """
     path = Path(map_resource.path.lstrip("/"))
 
-    minified_file, _ = path.name.split(".map")
+    minified_file = path.name.removesuffix(".map")
     minified_file_path = path.parent / minified_file
     minified_resource = minified_resources.get_or_none(path=minified_file_path)
 

--- a/scanpipe/templates/scanpipe/message_list.html
+++ b/scanpipe/templates/scanpipe/message_list.html
@@ -30,7 +30,7 @@
             <td style="max-width: 250px;">
               <div style="max-height: 200px; overflow-y: scroll;">
                 {% if message.description|length < 100 %}
-                  <a href="?message={{ message.description }}" class="is-black-link">{{ message.description }}</a>
+                  <a href="?description={{ message.description }}" class="is-black-link">{{ message.description }}</a>
                 {% else %}
                   {{ message.description }}
                 {% endif %}

--- a/scanpipe/tests/pipes/test_js.py
+++ b/scanpipe/tests/pipes/test_js.py
@@ -30,6 +30,7 @@ from scanpipe.pipes import js
 from scanpipe.pipes.input import copy_input
 from scanpipe.pipes.input import copy_inputs
 from scanpipe.pipes.pathmap import build_index
+from scanpipe.tests import make_resource_file
 
 
 class ScanPipeJsTest(TestCase):
@@ -180,6 +181,12 @@ class ScanPipeJsTest(TestCase):
         result = js.get_minified_resource(map_file, minified_resources)
 
         self.assertEqual(expected, result)
+
+    def test_scanpipe_pipes_js_get_minified_resource_multiple_map_occurrences(self):
+        resource = make_resource_file(self.project1, "main.map.js.map")
+        self.assertIsNone(
+            js.get_minified_resource(resource, self.project1.codebaseresources.all())
+        )
 
     def test_scanpipe_pipes_js_get_matches_by_ratio(self):
         to_dir = (


### PR DESCRIPTION
Also use `resource_path` in Project messages for rendering as a link in the UI