### PR TITLE
Refactor the BasePipeline, move out all Project related logic #1351

### DIFF
--- a/aboutcode/pipeline/README.md
+++ b/aboutcode/pipeline/README.md
@@ -1,0 +1,53 @@
+# `aboutcode.pipeline`
+
+Define and run pipelines.
+
+### Install
+
+```bash
+pip install aboutcode_pipeline
+```
+
+### Define and execute a pipeline
+
+```python
+from aboutcode.pipeline import BasePipeline
+
+class PrintMessages(BasePipeline):
+    @classmethod
+    def steps(cls):
+        return (cls.step1,)
+
+    def step1(self):
+        print("Message from step1")
+
+PrintMessages().execute()
+```
+
+### Groups and steps selection
+
+```python
+from aboutcode.pipeline import BasePipeline
+from aboutcode.pipeline import group
+
+class PrintMessages(BasePipeline):
+    @classmethod
+    def steps(cls):
+        return (cls.step1, cls.step2)
+
+    def step1(self):
+        print("Message from step1")
+
+    @group("foo")
+    def step2(self):
+        print("Message from step2")
+
+
+# Execute pipeline with group selection
+run = PrintMessages(selected_groups=["foo"])
+exitcode, error = run.execute()
+
+# Execute pipeline with steps selection
+run = PrintMessages(selected_steps=["step1"])
+exitcode, error = run.execute()
+```

--- a/aboutcode/pipeline/__init__.py
+++ b/aboutcode/pipeline/__init__.py
@@ -31,36 +31,6 @@ from timeit import default_timer as timer
 module_logger = logging.getLogger(__name__)
 
 
-"""
-from aboutcode.pipeline import BasePipeline
-from aboutcode.pipeline import group
-
-class PrintMessages(BasePipeline):
-    @classmethod
-    def steps(cls):
-        return (cls.step1, cls.step2)
-
-    def step1(self):
-        print("Message from step1")
-
-    @group("foo")
-    def step2(self):
-        print("Message from step2")
-
-
-# 1. Execute pipeline
-DoSomething().execute()
-
-# 2. Execute pipeline with group selection
-run = DoSomething(selected_groups=["foo"])
-exitcode, error = run.execute()
-
-# 3. Execute pipeline with steps selection
-run = DoSomething(selected_steps=["step1"])
-exitcode, error = run.execute()
-"""
-
-
 class PipelineDefinition:
     """
     Encapsulate the code related to a Pipeline definition:

--- a/aboutcode/pipeline/__init__.py
+++ b/aboutcode/pipeline/__init__.py
@@ -60,6 +60,9 @@ class PipelineDefinition:
 
         steps = cls.steps()
 
+        if initial_steps := cls.get_initial_steps():
+            steps = (*initial_steps, *steps)
+
         if groups is not None:
             steps = tuple(
                 step
@@ -175,13 +178,7 @@ class PipelineRun:
         """Execute each steps in the order defined on this pipeline class."""
         self.log(f"Pipeline [{self.pipeline_name}] starting")
 
-        # TODO: This is located on the PipelineDefinition class
         steps = self.pipeline_class.get_steps(groups=self.selected_groups)
-
-        # TODO: This is located on the PipelineDefinition class
-        if initial_steps := self.get_initial_steps():
-            steps = initial_steps + steps
-
         steps_count = len(steps)
         pipeline_start_time = timer()
 

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -44,11 +44,11 @@ from go_inspector.plugin import collect_and_parse_symbols
 from packagedcode.npm import NpmPackageJsonHandler
 from summarycode.classify import LEGAL_STARTS_ENDS
 
+from aboutcode.pipeline import LoopProgress
 from scanpipe import pipes
 from scanpipe.models import CodebaseRelation
 from scanpipe.models import CodebaseResource
 from scanpipe.models import convert_glob_to_django_regex
-from scanpipe.pipes import LoopProgress
 from scanpipe.pipes import flag
 from scanpipe.pipes import get_resource_diff_ratio
 from scanpipe.pipes import js

--- a/scanpipe/pipes/purldb.py
+++ b/scanpipe/pipes/purldb.py
@@ -32,7 +32,7 @@ from packageurl import PackageURL
 from univers.version_range import RANGE_CLASS_BY_SCHEMES
 from univers.version_range import InvalidVersionRange
 
-from scanpipe.pipes import LoopProgress
+from aboutcode.pipeline import LoopProgress
 from scanpipe.pipes import _clean_package_data
 
 

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -45,6 +45,7 @@ from scancode import api as scancode_api
 from scancode import cli as scancode_cli
 from scancode.cli import run_scan as scancode_run_scan
 
+from aboutcode.pipeline import LoopProgress
 from scanpipe import pipes
 from scanpipe.models import CodebaseResource
 from scanpipe.models import DiscoveredDependency
@@ -308,7 +309,7 @@ def scan_resources(
     resource_count = resource_qs.count()
     logger.info(f"Scan {resource_count} codebase resources with {scan_func.__name__}")
     resource_iterator = resource_qs.iterator(chunk_size=2000)
-    progress = pipes.LoopProgress(resource_count, logger=progress_logger)
+    progress = LoopProgress(resource_count, logger=progress_logger)
     max_workers = get_max_workers(keep_available=1)
 
     if max_workers <= 0:

--- a/scanpipe/pipes/strings.py
+++ b/scanpipe/pipes/strings.py
@@ -20,7 +20,7 @@
 # ScanCode.io is a free software code scanning tool from nexB Inc. and others.
 # Visit https://github.com/nexB/scancode.io for support and download.
 
-from scanpipe.pipes import LoopProgress
+from aboutcode.pipeline import LoopProgress
 
 
 class XgettextNotFound(Exception):

--- a/scanpipe/pipes/symbols.py
+++ b/scanpipe/pipes/symbols.py
@@ -22,7 +22,7 @@
 
 from django.db.models import Q
 
-from scanpipe.pipes import LoopProgress
+from aboutcode.pipeline import LoopProgress
 
 
 class UniversalCtagsNotFound(Exception):

--- a/scanpipe/tests/__init__.py
+++ b/scanpipe/tests/__init__.py
@@ -30,12 +30,14 @@ from scanpipe.models import CodebaseResource
 from scanpipe.models import DiscoveredDependency
 from scanpipe.models import DiscoveredPackage
 from scanpipe.tests.pipelines.do_nothing import DoNothing
+from scanpipe.tests.pipelines.download_inputs import DownloadInput
 from scanpipe.tests.pipelines.profile_step import ProfileStep
 from scanpipe.tests.pipelines.raise_exception import RaiseException
 
 scanpipe_app = apps.get_app_config("scanpipe")
 
 scanpipe_app.register_pipeline("do_nothing", DoNothing)
+scanpipe_app.register_pipeline("download_inputs", DownloadInput)
 scanpipe_app.register_pipeline("profile_step", ProfileStep)
 scanpipe_app.register_pipeline("raise_exception", RaiseException)
 

--- a/scanpipe/tests/pipelines/do_nothing.py
+++ b/scanpipe/tests/pipelines/do_nothing.py
@@ -30,6 +30,8 @@ class DoNothing(Pipeline):
     Description section of the doc string.
     """
 
+    download_inputs = False
+
     @classmethod
     def steps(cls):
         return (

--- a/scanpipe/tests/pipelines/download_inputs.py
+++ b/scanpipe/tests/pipelines/download_inputs.py
@@ -23,12 +23,15 @@
 from scanpipe.pipelines import Pipeline
 
 
-class StepsAsAttribute(Pipeline):
-    """Declare steps as attribute."""
+class DownloadInput(Pipeline):
+    """Define the download_inputs attribute as True"""
 
-    download_inputs = False
+    download_inputs = True
+
+    @classmethod
+    def steps(cls):
+        return (cls.step1,)
 
     def step1(self):
-        return
-
-    steps = (step1,)
+        """Step1 doc."""
+        pass

--- a/scanpipe/tests/pipelines/raise_exception.py
+++ b/scanpipe/tests/pipelines/raise_exception.py
@@ -26,6 +26,8 @@ from scanpipe.pipelines import Pipeline
 class RaiseException(Pipeline):
     """Raise an Exception."""
 
+    download_inputs = False
+
     @classmethod
     def steps(cls):
         return (cls.raise_exception_step,)

--- a/scanpipe/tests/pipelines/register_from_file.py
+++ b/scanpipe/tests/pipelines/register_from_file.py
@@ -26,6 +26,8 @@ from scanpipe.tests.pipelines.do_nothing import DoNothing
 class RegisterFromFile(DoNothing):
     """Register from its file path."""
 
+    download_inputs = False
+
     @classmethod
     def steps(cls):
         return (cls.step1,)

--- a/scanpipe/tests/pipelines/with_groups.py
+++ b/scanpipe/tests/pipelines/with_groups.py
@@ -27,6 +27,8 @@ from scanpipe.pipelines import Pipeline
 class WithGroups(Pipeline):
     """Include "grouped" steps."""
 
+    download_inputs = False
+
     @classmethod
     def steps(cls):
         return (

--- a/scanpipe/tests/pipes/test_pipes.py
+++ b/scanpipe/tests/pipes/test_pipes.py
@@ -28,6 +28,7 @@ from unittest import mock
 from django.test import TestCase
 from django.test import TransactionTestCase
 
+from aboutcode.pipeline import LoopProgress
 from scanpipe import pipes
 from scanpipe.models import CodebaseResource
 from scanpipe.models import DiscoveredPackage
@@ -348,14 +349,14 @@ class ScanPipePipesTransactionTest(TransactionTestCase):
 
         buffer = io.StringIO()
         logger = buffer.write
-        progress = pipes.LoopProgress(total_iterations, logger, progress_step=10)
+        progress = LoopProgress(total_iterations, logger, progress_step=10)
         for _ in progress.iter(range(total_iterations)):
             pass
         self.assertEqual(expected, buffer.getvalue())
 
         buffer = io.StringIO()
         logger = buffer.write
-        with pipes.LoopProgress(total_iterations, logger, progress_step) as progress:
+        with LoopProgress(total_iterations, logger, progress_step) as progress:
             for _ in progress.iter(range(total_iterations)):
                 pass
         self.assertEqual(expected, buffer.getvalue())

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -39,6 +39,7 @@ from scanpipe import pipes
 from scanpipe.models import CodebaseResource
 from scanpipe.models import DiscoveredPackage
 from scanpipe.models import Project
+from scanpipe.pipelines import CommonStepsMixin
 from scanpipe.pipelines import InputFilesError
 from scanpipe.pipelines import Pipeline
 from scanpipe.pipelines import deploy_to_develop
@@ -52,6 +53,7 @@ from scanpipe.tests import FIXTURES_REGEN
 from scanpipe.tests import make_package
 from scanpipe.tests import package_data1
 from scanpipe.tests.pipelines.do_nothing import DoNothing
+from scanpipe.tests.pipelines.download_inputs import DownloadInput
 from scanpipe.tests.pipelines.profile_step import ProfileStep
 from scanpipe.tests.pipelines.steps_as_attribute import StepsAsAttribute
 from scanpipe.tests.pipelines.with_groups import WithGroups
@@ -171,9 +173,13 @@ class ScanPipePipelinesTest(TestCase):
 
     def test_scanpipe_pipeline_class_download_inputs_attribute(self):
         project1 = Project.objects.create(name="Analysis")
-        run = project1.add_pipeline("do_nothing")
+        run = project1.add_pipeline("download_inputs")
         pipeline = run.make_pipeline_instance()
         self.assertTrue(pipeline.download_inputs)
+        expected = (CommonStepsMixin.download_missing_inputs,)
+        self.assertEqual(expected, pipeline.get_initial_steps())
+        expected = (CommonStepsMixin.download_missing_inputs, DownloadInput.step1)
+        self.assertEqual(expected, pipeline.get_steps())
         pipeline.execute()
         self.assertIn("Step [download_missing_inputs]", run.log)
 

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -152,10 +152,8 @@ class ScanPipePipelinesTest(TestCase):
 
         project1 = Project.objects.create(name="Analysis")
         run = project1.add_pipeline("do_nothing")
+        run.update(selected_steps=["step2", "not_existing_step"])
         pipeline = run.make_pipeline_instance()
-
-        run.selected_steps = ["step2", "not_existing_step"]
-        run.save()
 
         exitcode, out = pipeline.execute()
         self.assertEqual(0, exitcode)


### PR DESCRIPTION
Refactor the BasePipeline to remove the scanpipe.Project logic and make it reusable without Project context.