### PR TITLE
Add pyproject.toml for packaging aboutcode.pipeline module #1351

### DIFF
--- a/.github/workflows/pypi-release-aboutcode-pipeline.yml
+++ b/.github/workflows/pypi-release-aboutcode-pipeline.yml
@@ -1,0 +1,44 @@
+name: Build aboutcode.pipeline Python distributions and publish on PyPI
+
+on:
+  workflow_dispatch:
+  # push:
+  #   tags:
+  #     - "aboutcode.pipeline/v*.*.*"
+
+jobs:
+  build-and-publish:
+    name: Build and publish library to PyPI
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install flot
+        run: python -m pip install flot --user
+
+      - name: Build a binary wheel and a source tarball
+        run:  python -m flot --pyproject pipeline-pyproject.toml --sdist --wheel --output-dir dist/
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Upload built archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi_archives
+          path: dist/*
+
+      # - name: Create a GitHub release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     draft: true
+      #     files: dist/*

--- a/.github/workflows/pypi-release-aboutcode-pipeline.yml
+++ b/.github/workflows/pypi-release-aboutcode-pipeline.yml
@@ -2,9 +2,9 @@ name: Build aboutcode.pipeline Python distributions and publish on PyPI
 
 on:
   workflow_dispatch:
-  # push:
-  #   tags:
-  #     - "aboutcode.pipeline/v*.*.*"
+  push:
+   tags:
+     - "aboutcode.pipeline/*"
 
 jobs:
   build-and-publish:
@@ -36,9 +36,3 @@ jobs:
         with:
           name: pypi_archives
           path: dist/*
-
-      - name: Create a GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: false
-          files: dist/*

--- a/.github/workflows/pypi-release-aboutcode-pipeline.yml
+++ b/.github/workflows/pypi-release-aboutcode-pipeline.yml
@@ -37,8 +37,8 @@ jobs:
           name: pypi_archives
           path: dist/*
 
-      # - name: Create a GitHub release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     draft: true
-      #     files: dist/*
+      - name: Create a GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          files: dist/*

--- a/aboutcode/pipeline/CHANGELOG.md
+++ b/aboutcode/pipeline/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Release 0.1.0 (August 9, 2023)
+
+* Initial release of the `aboutcode.pipeline` library. [Issue #1351](https://github.com/nexB/scancode.io/issues/1351)

--- a/aboutcode/pipeline/README.md
+++ b/aboutcode/pipeline/README.md
@@ -5,7 +5,7 @@ Define and run pipelines.
 ### Install
 
 ```bash
-pip install aboutcode_pipeline
+pip install aboutcode.pipeline
 ```
 
 ### Define and execute a pipeline

--- a/aboutcode/pipeline/RELEASE.md
+++ b/aboutcode/pipeline/RELEASE.md
@@ -1,0 +1,29 @@
+# Release instructions for `aboutcode.pipeline`
+
+### Automated release workflow
+
+- Create a new `aboutcode.pipeline-release-x.x.x` branch
+- Update the version in:
+  - `pipeline-pyproject.toml`
+  - `aboutcode/pipeline/__init__.py`
+- Commit and push this branch
+- Create a PR and merge once approved
+- Tag and push to trigger the `pypi-release-aboutcode-pipeline.yml` workflow that 
+  takes care of building the distribution archives and upload those to pypi::
+  ```
+  VERSION=x.x.x  # <- Set the new version here
+  TAG=aboutcode.pipeline/$VERSION
+  git tag -a $TAG -m ""
+  git push origin $TAG
+  ```
+
+### Manual build
+
+```
+cd scancode.io
+source .venv/bin/activate
+pip install flot
+flot --pyproject pipeline-pyproject.toml --sdist --wheel --output-dir dist/
+```
+
+The distribution archives will be available in the local `dist/` directory.

--- a/aboutcode/pipeline/__init__.py
+++ b/aboutcode/pipeline/__init__.py
@@ -30,6 +30,8 @@ from timeit import default_timer as timer
 
 module_logger = logging.getLogger(__name__)
 
+__version__ = "0.1"
+
 
 class PipelineDefinition:
     """

--- a/aboutcode/pipeline/__init__.py
+++ b/aboutcode/pipeline/__init__.py
@@ -30,7 +30,7 @@ from timeit import default_timer as timer
 
 module_logger = logging.getLogger(__name__)
 
-__version__ = "0.1"
+__version__ = "0.1.0"
 
 
 class PipelineDefinition:

--- a/pipeline-pyproject.toml
+++ b/pipeline-pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flot.buildapi"
 
 [project]
 name = "aboutcode.pipeline"
-version = "0.1"
+version = "0.1.0"
 description = "AboutCode Pipeline library. Execute code in steps."
 license = { text = "Apache-2.0" }
 readme = "aboutcode/pipeline/README.md"
@@ -31,6 +31,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/nexB/scancode.io"
 Documentation = "https://scancodeio.readthedocs.io/"
+Changelog = "https://github.com/nexB/scancode.io/tree/main/aboutcode/pipeline/CHANGELOG.md"
 Repository = "https://github.com/nexB/scancode.io/tree/main/aboutcode/pipeline"
 Issues = "https://github.com/nexB/scancode.io/issues"
 

--- a/pipeline-pyproject.toml
+++ b/pipeline-pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["flot"]
+build-backend = "flot.buildapi"
+
+[project]
+name = "aboutcode.pipeline"
+version = "0.1"
+description = "AboutCode Pipeline library. Execute code in steps."
+license = { text = "Apache-2.0" }
+readme = "aboutcode/pipeline/README.md"
+requires-python = ">=3.9"
+authors = [ { name = "nexB. Inc. and others", email = "info@aboutcode.org" } ]
+keywords = [
+    "open source",
+    "pipeline",
+    "scancode",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development",
+    "Topic :: Utilities",
+]
+
+[project.urls]
+Homepage = "https://github.com/nexB/scancode.io"
+Documentation = "https://scancodeio.readthedocs.io/"
+Repository = "https://github.com/nexB/scancode.io/tree/main/aboutcode/pipeline"
+Issues = "https://github.com/nexB/scancode.io/issues"
+
+[tool.flot]
+includes = [
+    "aboutcode/pipeline/*",
+]
+metadata_files = [
+    "LICENSE",
+    "NOTICE",
+]


### PR DESCRIPTION
The dist archives can be manually built with:

```
$ cd scancode.io
$ source .venv/bin/activate
$ pip install flot
$ flot --pyproject pipeline-pyproject.toml --sdist --wheel --output-dir dist/
```

Also, regarding https://github.com/nexB/scancode.io/pull/1358#discussion_r1709767929, it seems that using the `aboutcode.pipeline` works fine:

```
pip install aboutcode.pipeline --find-links=scancode.io/dist --no-index --no-cache-dir
# Successfully installed aboutcode.pipeline-0.1

pip install aboutcode_pipeline --find-links=scancode.io/dist --no-index --no-cache-dir
# Successfully installed aboutcode_pipeline-0.1

pip install aboutcode-pipeline --find-links=scancode.io/dist --no-index --no-cache-dir
# Successfully installed aboutcode-pipeline-0.1
```

@keshav-space could you adapt and add the `pypi-release-abc-pipeline.yml` (let's use `pypi-release-aboutcode-pipeline.yml`) from https://github.com/nexB/scancode.io/pull/1332/files#diff-bbcc61089df1f0d385697aff0c2da0e9c972d8cf73acfe27f8cb437df2e92b46

Let's make sure we have a separate tag convention to trigger the releases of aboutcode.pipeline  independently of the ScanCode.io releases.