### PR TITLE
changing tool_name from scanpipe to ScanCode.io

### DIFF
--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -232,7 +232,7 @@ class JSONResultsGenerator:
         other_tools = [f"pkg:pypi/scancode-toolkit@{scancode_toolkit_version}"]
 
         headers = {
-            "tool_name": "scanpipe",
+            "tool_name": "ScanCode.io",
             "tool_version": scancodeio_version,
             "other_tools": other_tools,
             "notice": SCAN_NOTICE,

--- a/scanpipe/tests/data/asgiref/asgiref-3.3.0_load_inventory_expected.json
+++ b/scanpipe/tests/data/asgiref/asgiref-3.3.0_load_inventory_expected.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/asgiref/asgiref-3.3.0_scanpipe_output.json
+++ b/scanpipe/tests/data/asgiref/asgiref-3.3.0_scanpipe_output.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "tool_version": "v34.8.2-2-gdde1fc5b",
       "other_tools": [
         "pkg:pypi/scancode-toolkit@v34.8.2-2-gdde1fc5b"

--- a/scanpipe/tests/data/d2d/about_files/expected.json
+++ b/scanpipe/tests/data/d2d/about_files/expected.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/d2d/flume-ng-node-d2d-input.json
+++ b/scanpipe/tests/data/d2d/flume-ng-node-d2d-input.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [],
       "runs": [

--- a/scanpipe/tests/data/d2d/flume-ng-node-d2d.json
+++ b/scanpipe/tests/data/d2d/flume-ng-node-d2d.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/dependencies/resolved_dependencies_cocoapods.json
+++ b/scanpipe/tests/data/dependencies/resolved_dependencies_cocoapods.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/dependencies/resolved_dependencies_npm_inspect_packages.json
+++ b/scanpipe/tests/data/dependencies/resolved_dependencies_npm_inspect_packages.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/dependencies/resolved_dependencies_nuget.json
+++ b/scanpipe/tests/data/dependencies/resolved_dependencies_nuget.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/dependencies/resolved_dependencies_pip.json
+++ b/scanpipe/tests/data/dependencies/resolved_dependencies_pip.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/dependencies/resolved_dependencies_poetry_inspect_packages.json
+++ b/scanpipe/tests/data/dependencies/resolved_dependencies_poetry_inspect_packages.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/dependencies/resolved_dependencies_swift_inspect_packages.json
+++ b/scanpipe/tests/data/dependencies/resolved_dependencies_swift_inspect_packages.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/docker/alpine_3_15_4_scan_codebase.json
+++ b/scanpipe/tests/data/docker/alpine_3_15_4_scan_codebase.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/docker/debian_scan_codebase.json
+++ b/scanpipe/tests/data/docker/debian_scan_codebase.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/docker/gcr_io_distroless_base_scan_codebase.json
+++ b/scanpipe/tests/data/docker/gcr_io_distroless_base_scan_codebase.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/image-with-symlinks/minitag.tar-expected-scan.json
+++ b/scanpipe/tests/data/image-with-symlinks/minitag.tar-expected-scan.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/matchcode/match_to_matchcode/codebase.json
+++ b/scanpipe/tests/data/matchcode/match_to_matchcode/codebase.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "tool_version": "v3.0.0-241-g45d653b",
       "other_tools": [
         "pkg:pypi/scancode-toolkit@32.0.8"

--- a/scanpipe/tests/data/rootfs/basic-rootfs_root_filesystems.json
+++ b/scanpipe/tests/data/rootfs/basic-rootfs_root_filesystems.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/scancode/daglib-0.6.0-py3-none-any.whl_scan_codebase.json
+++ b/scanpipe/tests/data/scancode/daglib-0.6.0-py3-none-any.whl_scan_codebase.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {

--- a/scanpipe/tests/data/scancode/is-npm-1.0.0_scan_codebase.json
+++ b/scanpipe/tests/data/scancode/is-npm-1.0.0_scan_codebase.json
@@ -1,7 +1,7 @@
 {
   "headers": [
     {
-      "tool_name": "scanpipe",
+      "tool_name": "ScanCode.io",
       "notice": "Generated with ScanCode.io and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied.\nNo content created from ScanCode.io should be considered or used as legal advice.\nConsult an Attorney for any legal advice.\nScanCode.io is a free software code scanning tool from nexB Inc. and others\nlicensed under the Apache License version 2.0.\nScanCode is a trademark of nexB Inc.\nVisit https://github.com/nexB/scancode.io for support and download.\n",
       "input_sources": [
         {


### PR DESCRIPTION
This PR fixes #1556 
Replaced all instances of `tool_name` from `scanpipe` to `ScanCode.io`