### PR TITLE
Add WHITE_OUT flag for whiteout files instead of IGNORED_WHITEOUT || issue #1528

### DIFF
--- a/scanpipe/pipes/docker.py
+++ b/scanpipe/pipes/docker.py
@@ -268,13 +268,13 @@ def scan_image_for_system_packages(project, image):
 
 def flag_whiteout_codebase_resources(project):
     """
-    Tag overlayfs/AUFS whiteout special files CodebaseResource as "ignored-whiteout".
+    Tag overlayfs/AUFS whiteout special files CodebaseResource as "white-out".
     See https://github.com/opencontainers/image-spec/blob/master/layer.md#whiteouts
     for details.
     """
     whiteout_prefix = ".wh."
     qs = project.codebaseresources.no_status()
-    qs.filter(name__startswith=whiteout_prefix).update(status=flag.IGNORED_WHITEOUT)
+    qs.filter(name__startswith=whiteout_prefix).update(status=flag.WHITE_OUT)
 
 
 layer_fields = [

--- a/scanpipe/pipes/flag.py
+++ b/scanpipe/pipes/flag.py
@@ -36,6 +36,8 @@ NOT_ANALYZED = "not-analyzed"
 
 RESOURCE_READ_ERROR = "resource-read-error"
 
+WHITE_OUT = "white-out"
+
 IGNORED_WHITEOUT = "ignored-whiteout"
 IGNORED_EMPTY_FILE = "ignored-empty-file"
 IGNORED_WHITESPACE_FILE = "ignored-whitespace-file"

--- a/scanpipe/tests/pipes/test_docker.py
+++ b/scanpipe/tests/pipes/test_docker.py
@@ -90,7 +90,7 @@ class ScanPipeDockerPipesTest(TestCase):
         resource1.refresh_from_db()
         resource2.refresh_from_db()
         self.assertEqual("", resource1.status)
-        self.assertEqual("ignored-whiteout", resource2.status)
+        self.assertEqual("white-out", resource2.status)
 
     def test_pipes_docker_extract_image_from_tarball_with_broken_symlinks(
         self,


### PR DESCRIPTION
This PR implements a new WHITE_OUT flag to tag Docker whiteout files as "white-out" instead of "ignored-whiteout", making them more visible in scan results for better security analysis and risk assessment.