### PR TITLE
Workflow updates to use depscan v6 beta

### DIFF
--- a/.github/workflows/sca-integration-cdxgen.yml
+++ b/.github/workflows/sca-integration-cdxgen.yml
@@ -34,7 +34,8 @@ jobs:
             --output cdxgen-sbom.cdx.json \
             --spec-version 1.6 \
             --json-pretty
-
+        env:
+          CDXGEN_TEMP_DIR: ${{ runner.temp }}/cdxgen-temp
       - name: Upload SBOM as GitHub Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/sca-integration-depscan.yml
+++ b/.github/workflows/sca-integration-depscan.yml
@@ -24,10 +24,10 @@ jobs:
   generate-and-load-sbom:
     runs-on: ubuntu-24.04
     steps:
-      - name: Install OWASP dep-scan
+      - name: Install OWASP dep-scan v6 beta
         run: |
           sudo npm install -g @cyclonedx/cdxgen
-          pip install owasp-depscan
+          pip install --pre owasp-depscan[all]
 
       - name: Generate SBOM with OWASP dep-scan
         run: |
@@ -36,6 +36,10 @@ jobs:
             --type docker \
             --reports-dir reports \
             --explain
+        env:
+          CDXGEN_TEMP_DIR: ${{ runner.temp }}/cdxgen-temp
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUTF8: 1
 
       - name: Upload SBOM as GitHub Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently, the workflow is testing the depscan v5 release, which has known limitations. In addition, cdxgen has known limitations generating SBOMs with the default temp directory in GitHub-hosted agents.

This PR updates the pip install to install the depscan v6 prerelease. In addition, the cdxgen temp directory is set via environment variables.