### PR TITLE
Pin click to version 8.2.1 #1885

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,8 @@ dependencies = [
   "scipy==1.15.3",
   # ScoreCode
   "scorecode==0.0.4",
-
+  # Workaround issue https://github.com/aboutcode-org/scancode.io/issues/1885
+  "click==8.2.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
click v8.3.0 has changed some behavior with the `click.Option` constructor arguments, causing a `TypeError` exception to be raised when instantiating scancode-toolkit. This PR pins click to version 8.2.1 to avoid this problem until a proper solution is available in https://github.com/aboutcode-org/scancode-toolkit/pull/4571 and available in a new release