### PR TITLE
Bump version to v35.4.0 for release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v35.4.0 (unreleased)
+v35.4.0 (2025-09-30)
 --------------------
 
 - Use deterministic UID/GID in Dockerfile.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scancodeio"
-version = "35.3.0"
+version = "35.4.0"
 description = "Automate software composition analysis pipelines"
 readme = "README.rst"
 requires-python = ">=3.10,<3.14"

--- a/scancodeio/__init__.py
+++ b/scancodeio/__init__.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import git
 
-VERSION = "35.3.0"
+VERSION = "35.4.0"
 
 PROJECT_DIR = Path(__file__).resolve().parent
 ROOT_DIR = PROJECT_DIR.parent


### PR DESCRIPTION
Reference: https://github.com/aboutcode-org/scancode.io/issues/1885

We have a fix at https://github.com/aboutcode-org/scancode.io/pull/1887 by @JonoYang but this needs to be released to fix the `scancode-action` pipeline errors.
