### PR TITLE
Fix placeholder text for Download URLs field to use correct purl-spec…

### DIFF
--- a/scanpipe/forms.py
+++ b/scanpipe/forms.py
@@ -74,7 +74,7 @@ class InputsBaseForm(forms.Form):
                 "placeholder": (
                     "https://domain.com/archive.zip\n"
                     "docker://docker-reference (e.g.: docker://postgres:13)\n"
-                    "pkg://type/name@version"
+                    "pkg:type/name@version (e.g.: pkg:pypi/django@1.11.1)"
                 ),
             },
         ),


### PR DESCRIPTION
Replaced incorrect `pkg://type/name@version` with correct `pkg:type/name@version`
according to the official purl-spec. Added example `pkg:pypi/django@1.11.1` for clarity.

Fixes #1882 

Signed-off-by: Aryan Singh <aryansingh12oct2005@gmail.com>
