### PR TITLE
fix: cargo scanning failure 

### DIFF
--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -2997,7 +2997,10 @@ class CodebaseResource(
         else:
             parent_path = self.compute_parent_directory()
 
-        return parent_path and self.project.codebaseresources.get(path=parent_path)
+        if parent_path:
+            with suppress(ObjectDoesNotExist):
+                return self.project.codebaseresources.get(path=parent_path)
+        return None
 
     def siblings(self, codebase=None):
         """
@@ -4184,7 +4187,7 @@ class DiscoveredDependency(
             if strip_datafile_path_root:
                 segments = datafile_path.split("/")
                 datafile_path = "/".join(segments[1:])
-            datafile_resource = project.codebaseresources.get(path=datafile_path)
+            datafile_resource = project.codebaseresources.get_or_none(path=datafile_path)
 
         if datasource_id:
             dependency_data["datasource_id"] = datasource_id


### PR DESCRIPTION
fixes aboutcode-org/scancode-toolkit#4581
On scanning https://raw.githubusercontent.com/cesarb/constant_time_eq/refs/heads/main/Cargo.toml with the inspect_packages pipeline or scan_codebase 
the scan pases !! 
logs: 
```
2025-10-09 10:53:45.652 Pipeline [scan_codebase] starting
2025-10-09 10:53:45.654 Step [download_missing_inputs] starting
2025-10-09 10:53:45.656 Fetching input from https://raw.githubusercontent.com/cesarb/constant_time_eq/refs/heads/main/Cargo.toml
2025-10-09 10:53:45.778 Step [download_missing_inputs] completed in 0 seconds
2025-10-09 10:53:45.780 Step [copy_inputs_to_codebase_directory] starting
2025-10-09 10:53:45.783 Step [copy_inputs_to_codebase_directory] completed in 0 seconds
2025-10-09 10:53:45.785 Step [extract_archives] starting
2025-10-09 10:53:45.797 Step [extract_archives] completed in 0 seconds
2025-10-09 10:53:45.800 Step [collect_and_create_codebase_resources] starting
2025-10-09 10:53:45.814 Step [collect_and_create_codebase_resources] completed in 0 seconds
2025-10-09 10:53:45.816 Step [flag_empty_files] starting
2025-10-09 10:53:45.823 Step [flag_empty_files] completed in 0 seconds
2025-10-09 10:53:45.824 Step [flag_ignored_resources] starting
2025-10-09 10:53:45.830 Step [flag_ignored_resources] completed in 0 seconds
2025-10-09 10:53:45.832 Step [scan_for_application_packages] starting
2025-10-09 10:53:45.834 Collecting package data from resources:
2025-10-09 10:53:48.686 Assembling collected package data:
2025-10-09 10:53:48.688 Progress: 0%
2025-10-09 10:53:48.693 Step [scan_for_application_packages] completed in 3 seconds
2025-10-09 10:53:48.694 Step [scan_for_files] starting
2025-10-09 10:53:48.698 Step [scan_for_files] completed in 0 seconds
2025-10-09 10:53:48.715 Step [collect_and_create_license_detections] starting
2025-10-09 10:53:48.736 Step [collect_and_create_license_detections] completed in 0 seconds
2025-10-09 10:53:48.737 Pipeline completed in 3 seconds 
```
with perfectly detecting the licences !! 

<img width="1259" height="699" alt="Screenshot 2025-10-09 at 4 25 21 PM" src="https://github.com/user-attachments/assets/12dce06e-87be-44ab-9892-2aa89f23d4e6" />
