### PR TITLE
Refine D2D with Grammar (.g/.g4) Class Mapping #1808

### DIFF
--- a/scanpipe/pipelines/deploy_to_develop.py
+++ b/scanpipe/pipelines/deploy_to_develop.py
@@ -80,6 +80,9 @@ class DeployToDevelop(Pipeline):
             cls.find_kotlin_packages,
             cls.map_kotlin_to_class,
             cls.map_jar_to_kotlin_source,
+            cls.find_grammar_packages,
+            cls.map_grammar_to_class,
+            cls.map_jar_to_grammar_source,
             cls.map_javascript,
             cls.map_javascript_symbols,
             cls.map_javascript_strings,
@@ -233,6 +236,27 @@ class DeployToDevelop(Pipeline):
         """Map .jar files to their related source directory."""
         d2d.map_jar_to_jvm_source(
             project=self.project, jvm_lang=jvm.KotlinLanguage, logger=self.log
+        )
+
+    @optional_step("Grammar")
+    def find_grammar_packages(self):
+        """Find the java package of the .g/.g4 source files."""
+        d2d.find_jvm_packages(
+            project=self.project, jvm_lang=jvm.GrammarLanguage, logger=self.log
+        )
+
+    @optional_step("Grammar")
+    def map_grammar_to_class(self):
+        """Map a .class compiled file to its .g/.g4 source."""
+        d2d.map_jvm_to_class(
+            project=self.project, jvm_lang=jvm.GrammarLanguage, logger=self.log
+        )
+
+    @optional_step("Grammar")
+    def map_jar_to_grammar_source(self):
+        """Map .jar files to their related source directory."""
+        d2d.map_jar_to_jvm_source(
+            project=self.project, jvm_lang=jvm.GrammarLanguage, logger=self.log
         )
 
     @optional_step("JavaScript")

--- a/scanpipe/pipes/jvm.py
+++ b/scanpipe/pipes/jvm.py
@@ -208,6 +208,15 @@ class KotlinLanguage(JvmLanguage):
         return str(path.parent / f"{class_name}{extension}")
 
 
+class GrammarLanguage(JvmLanguage):
+    name = "grammar"
+    source_extensions = (".g", ".g4")
+    binary_extensions = (".class",)
+    source_package_attribute_name = "grammar_package"
+    package_regex = re.compile(r"^\s*package\s+([\w\.]+)\s*;?")
+    binary_map_type = "grammar_to_class"
+
+
 def get_fully_qualified_path(jvm_package, filename):
     """
     Return a fully qualified path of a ``filename`` in a

--- a/scanpipe/tests/pipes/test_d2d.py
+++ b/scanpipe/tests/pipes/test_d2d.py
@@ -439,6 +439,32 @@ class ScanPipeD2DPipesTest(TestCase):
         expected = {"from_source_root": "from/flume-ng-node-1.9.0-sources.jar-extract/"}
         self.assertEqual(expected, relation2.extra_data)
 
+    def test_scanpipe_pipes_d2d_map_grammar_to_class(self):
+        from1 = make_resource_file(
+            self.project1,
+            path="from/antlr4-4.5.1-beta-1/tool/src/org/antlr/v4/parse/BlockSetTransformer.g",
+            extra_data={"grammar_package": "org.antlr.v4.parse"},
+        )
+
+        to1 = make_resource_file(
+            self.project1,
+            path="to/org/antlr/v4/parse/BlockSetTransformer.class",
+        )
+
+        buffer = io.StringIO()
+        d2d.map_jvm_to_class(
+            self.project1, logger=buffer.write, jvm_lang=jvm.GrammarLanguage
+        )
+
+        expected = "Mapping 1 .class resources to 1 ('.g', '.g4')"
+        self.assertIn(expected, buffer.getvalue())
+        self.assertEqual(1, self.project1.codebaserelations.count())
+
+        r1 = self.project1.codebaserelations.get(to_resource=to1, from_resource=from1)
+        self.assertEqual("grammar_to_class", r1.map_type)
+        expected = {"from_source_root": "from/antlr4-4.5.1-beta-1/tool/src/"}
+        self.assertEqual(expected, r1.extra_data)
+
     def test_scanpipe_pipes_d2d_map_java_to_class_no_java(self):
         make_resource_file(self.project1, path="to/Abstract.class")
         buffer = io.StringIO()


### PR DESCRIPTION
<img width="1116" height="208" alt="Screenshot 2025-10-29 113847" src="https://github.com/user-attachments/assets/de7090cb-eb61-42cf-9c16-39ab42c1ba87" />

Support mapping `.class` to their corresponding grammar definitions (.g / .g4) files.

Note that grammar files are not exclusive to Java; they can also be used for Python, C++, PHP, and other languages.
This PR focuses solely on `.class` mapping.
Further enhancements can be made over time.
