### PR TITLE
[CRAVEX] Generic CI/CD integration

### DIFF
--- a/docs/automation.rst
+++ b/docs/automation.rst
@@ -75,8 +75,8 @@ Integrate ScanCode.io into your Jenkins pipelines with a simple Jenkinsfile.
 **Full documentation:**
 https://github.com/aboutcode-org/scancode-action/blob/main/jenkins/README.md
 
-GitLab CI/CD
-^^^^^^^^^^^^
+GitLab
+^^^^^^
 
 Run ScanCode.io scans in your GitLab pipelines.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -183,22 +183,31 @@ See the :ref:`installation` chapter for the full list of installation options.
 Integrate with Your Workflows
 -----------------------------
 
-ScanCode.io can be part of your CI/CD workflow.
+ScanCode.io integrates seamlessly into CI/CD pipelines, enabling automated scans on
+commits, pull requests, releases, and scheduled events.
+
+**Supported platforms:**
+
+- **GitHub Actions** - Official action with built-in compliance checks
+- **GitLab** - Docker-based pipeline integration
+- **Jenkins** - Jenkinsfile integration with artifact archiving
+- **Azure Pipelines** - Azure DevOps pipeline support
+- **Any CI/CD system** - Direct Docker command integration
 
 GitHub Actions
 ^^^^^^^^^^^^^^
 
 Use the official `scancode-action <https://github.com/aboutcode-org/scancode-action>`_
-to integrate **ScanCode.io into your GitHub workflows** with ease.
+to integrate ScanCode.io into your GitHub workflows.
 
-This action lets you:
+**Features:**
 
-- **Run pipelines**
-- **Check for compliance issues**
-- **Detect vulnerabilities**
-- **Generate SBOMs and scan results**
+- Run pipelines automatically on repository events
+- Check for compliance issues and policy violations
+- Detect security vulnerabilities
+- Generate SBOMs in multiple formats (SPDX, CycloneDX)
 
-Example usage:
+**Example usage:**
 
 .. code-block:: yaml
 
@@ -212,8 +221,10 @@ Example usage:
           pipelines: "scan_codebase"
           output-formats: "json xlsx spdx cyclonedx"
 
-Full details available at:
-https://github.com/aboutcode-org/scancode-action
+**Learn more:** https://github.com/aboutcode-org/scancode-action
 
-.. tip::
-    Learn more about automation options in the :ref:`automation` section.
+Other CI/CD Platforms
+^^^^^^^^^^^^^^^^^^^^^
+
+For setup instructions and examples for other platforms, see the :ref:`automation`
+section.


### PR DESCRIPTION
Issue: https://github.com/aboutcode-org/scancode.io/issues/1735

This PR adds documentation about Generic CI/CD integration.
The generic integration was also made possible thanks to the changes made at https://github.com/aboutcode-org/scancode.io/pull/1916

The CI/CD Integrations documentation is available at https://scancodeio.readthedocs.io/en/latest/automation.html#other-ci-cd-systems