### PR TITLE
Refine D2D with Xtend and Class Mapping #1906

### DIFF
--- a/scanpipe/pipelines/deploy_to_develop.py
+++ b/scanpipe/pipelines/deploy_to_develop.py
@@ -83,6 +83,8 @@ class DeployToDevelop(Pipeline):
             cls.find_grammar_packages,
             cls.map_grammar_to_class,
             cls.map_jar_to_grammar_source,
+            cls.find_xtend_packages,
+            cls.map_xtend_to_class,
             cls.map_javascript,
             cls.map_javascript_symbols,
             cls.map_javascript_strings,
@@ -257,6 +259,20 @@ class DeployToDevelop(Pipeline):
         """Map .jar files to their related source directory."""
         d2d.map_jar_to_jvm_source(
             project=self.project, jvm_lang=jvm.GrammarLanguage, logger=self.log
+        )
+
+    @optional_step("Xtend")
+    def find_xtend_packages(self):
+        """Find the java package of the xtend source files."""
+        d2d.find_jvm_packages(
+            project=self.project, jvm_lang=jvm.XtendLanguage, logger=self.log
+        )
+
+    @optional_step("Xtend")
+    def map_xtend_to_class(self):
+        """Map a .class compiled file to its xtend source."""
+        d2d.map_jvm_to_class(
+            project=self.project, jvm_lang=jvm.XtendLanguage, logger=self.log
         )
 
     @optional_step("JavaScript")

--- a/scanpipe/pipes/jvm.py
+++ b/scanpipe/pipes/jvm.py
@@ -217,6 +217,15 @@ class GrammarLanguage(JvmLanguage):
     binary_map_type = "grammar_to_class"
 
 
+class XtendLanguage(JvmLanguage):
+    name = "xtend"
+    source_extensions = (".xtend",)
+    binary_extensions = (".class",)
+    source_package_attribute_name = "xtend_package"
+    package_regex = re.compile(r"^\s*package\s+([\w\.]+)\s*;?")
+    binary_map_type = "xtend_to_class"
+
+
 def get_fully_qualified_path(jvm_package, filename):
     """
     Return a fully qualified path of a ``filename`` in a

--- a/scanpipe/tests/pipes/test_d2d.py
+++ b/scanpipe/tests/pipes/test_d2d.py
@@ -461,6 +461,34 @@ class ScanPipeD2DPipesTest(TestCase):
         expected = {"from_source_root": "from/antlr4-4.5.1-beta-1/tool/src/"}
         self.assertEqual(expected, r1.extra_data)
 
+    def test_scanpipe_pipes_d2d_map_xtend_to_class(self):
+        from1 = make_resource_file(
+            self.project1,
+            path="from/org.openhab.binding.urtsi/src/main/java/org/openhab/"
+            + "binding/urtsi/internal/UrtsiDevice.xtend",
+            extra_data={"xtend_package": "org.openhab.binding.urtsi.internal"},
+        )
+
+        to1 = make_resource_file(
+            self.project1,
+            path="to/org.openhab.binding.urtsi-1.6.2.jar-extract/org/"
+            + "openhab/binding/urtsi/internal/UrtsiDevice.class",
+        )
+
+        buffer = io.StringIO()
+        d2d.map_jvm_to_class(
+            self.project1, logger=buffer.write, jvm_lang=jvm.XtendLanguage
+        )
+
+        expected = "Mapping 1 .class resources to 1 ('.xtend',)"
+        self.assertIn(expected, buffer.getvalue())
+        self.assertEqual(1, self.project1.codebaserelations.count())
+
+        r1 = self.project1.codebaserelations.get(to_resource=to1, from_resource=from1)
+        self.assertEqual("xtend_to_class", r1.map_type)
+        expected = {"from_source_root": "from/org.openhab.binding.urtsi/src/main/java/"}
+        self.assertEqual(expected, r1.extra_data)
+
     def test_scanpipe_pipes_d2d_map_java_to_class_no_java(self):
         make_resource_file(self.project1, path="to/Abstract.class")
         buffer = io.StringIO()


### PR DESCRIPTION
Fix for #1906

Support mapping `.class` to their corresponding `.xtend` files.

The reported .class is now mapped with the corresponding `.xtend`
<img width="1855" height="547" alt="Screenshot 2025-11-07 103543" src="https://github.com/user-attachments/assets/1f5ea3c6-522f-4961-af5d-1dc3d10fdbb1" />

Map type is `xtend_to_class`
<img width="1121" height="408" alt="Screenshot 2025-11-07 103601" src="https://github.com/user-attachments/assets/e93e353d-30e9-4a19-a2f9-d2cb7d213ef0" />
