### PR TITLE
Alternative worker to avoid TLS connection issues to DB

### DIFF
--- a/scancodeio/worker.py
+++ b/scancodeio/worker.py
@@ -23,13 +23,43 @@
 from django.apps import apps
 
 from rq.queue import Queue
-from rq.worker import Worker
+from rq.worker import Worker, SimpleWorker
 
 scanpipe_app = apps.get_app_config("scanpipe")
 
 
 class ScanCodeIOWorker(Worker):
     """Modified version of RQ Worker including ScanCode.io customizations."""
+
+    def run_maintenance_tasks(self):
+        """
+        Add Runs and Jobs synchronization to the periodic maintenance tasks.
+        Maintenance tasks should run on first worker startup or every 10 minutes.
+
+        During the maintenance, one of the worker will acquire a "cleaning lock" and
+        will run the registries cleanup.
+        During that cleanup, started Jobs that haven't sent a heartbeat in the past 90
+        seconds (job_monitoring_interval + 60) will be considered failed and will be
+        moved to the FailedJobRegistry.
+        This happens when the Job process is killed (voluntary or not) and the heartbeat
+        is the RQ approach to determine if the job is stills active.
+        The `sync_runs_and_jobs` will see this Job as failed and will update its related
+        Run accordingly.
+        """
+        super().run_maintenance_tasks()
+
+        # The Runs and Jobs synchronization needs to be executed after the
+        # `self.clean_registries()` that takes place in the parent
+        # `super().run_maintenance_tasks()`.
+        scanpipe_app.sync_runs_and_jobs()
+
+
+class ScanCodeIOSimpleWorker(SimpleWorker):
+    """
+    Modified version of RQ SimpleWorker including ScanCode.io customizations.
+    This class can be used when encountering TLS connection issues to the database,
+    as shown in https://github.com/aboutcode-org/scancode.io/issues/1523
+    """
 
     def run_maintenance_tasks(self):
         """


### PR DESCRIPTION
The tech stack of django-rq seems to have issues with TLS connections getting corrupted when using `Worker` (forks/multiprocessing). This is relevant when an external database is used. The alternative is to also implement a worker based on `SimpleWorker` which does not fork and does not experience this bug. This alternative worker could be configured via the `--worker-class` option of the `rqworker`, just as the `scancodeio.worker.ScanCodeIOWorker` is currently set in the docker compose files. For reference see: 
- https://github.com/aboutcode-org/scancode.io/issues/1523
- https://github.com/rq/django-rq/issues/650 
- https://github.com/aboutcode-org/scancode.io/blob/a89488815cad3e1e8987c0ddc98afff147d43c2a/docker-compose.yml#L86