### PR TITLE
Only run code stemming on source files that we can handle in `fingerprint_stemmed_codebase_resources`

### DIFF
--- a/scanpipe/pipes/matchcode.py
+++ b/scanpipe/pipes/matchcode.py
@@ -30,6 +30,7 @@ from matchcode_toolkit.fingerprinting import compute_codebase_directory_fingerpr
 from matchcode_toolkit.fingerprinting import get_file_fingerprint_hashes
 from matchcode_toolkit.fingerprinting import get_line_by_pos
 from matchcode_toolkit.fingerprinting import get_stemmed_file_fingerprint_hashes
+from matchcode_toolkit.stemming import TS_LANGUAGE_CONF
 from scancode import Scanner
 
 from scanpipe.pipes import codebase
@@ -285,7 +286,9 @@ def fingerprint_stemmed_codebase_resources(
     """
     # Checking for None to make the distinction with an empty resource_qs queryset
     if resource_qs is None:
-        resource_qs = project.codebaseresources.filter(is_text=True)
+        resource_qs = project.codebaseresources.filter(
+            programming_language__in=TS_LANGUAGE_CONF.keys()
+        )
 
     if to_codebase_only:
         resource_qs = resource_qs.to_codebase()

--- a/scanpipe/tests/pipes/test_matchcode.py
+++ b/scanpipe/tests/pipes/test_matchcode.py
@@ -399,7 +399,10 @@ class MatchCodePipesTest(TestCase):
             self.project1.codebase_path,
         )
         codebase_resource3 = CodebaseResource.objects.create(
-            project=self.project1, path="inherits.js", is_text=True
+            project=self.project1,
+            path="inherits.js",
+            is_text=True,
+            programming_language="JavaScript",
         )
 
         matchcode.fingerprint_stemmed_codebase_resources(self.project1)


### PR DESCRIPTION
This PR updates `scanpipe.pipes.matchcode.fingerprint_stemmed_codebase_resources` to filter for source code that the stemming code can handle rather than run it on all text resources.