### PR TITLE
Add "ort-package-list" to the formats list in `run` command

### DIFF
--- a/scanpipe/management/commands/run.py
+++ b/scanpipe/management/commands/run.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--format",
             default="json",
-            choices=["json", "spdx", "cyclonedx", "attribution"],
+            choices=["json", "spdx", "cyclonedx", "attribution", "ort-package-list"],
             help="Specifies the output serialization format for the results.",
         )
 


### PR DESCRIPTION
Reference: #1980

Minimal fix, see also https://github.com/aboutcode-org/scancode.io/pull/1981