### PR TITLE
Perform basic mapping before normalizing mapping

### DIFF
--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -170,12 +170,21 @@ def _map_jvm_to_class_resource(
     from/ fully qualified binary files.
     """
     for extension in jvm_lang.source_extensions:
-        normalized_path = jvm_lang.get_normalized_path(
+        # Perform basic conversion from .class to source file path
+        source_path = jvm_lang.get_source_path(
             path=to_resource.path, extension=extension
         )
-        match = pathmap.find_paths(path=normalized_path, index=from_classes_index)
+        # Perform basic mapping without normalization for scenarios listed in
+        # https://github.com/aboutcode-org/scancode.io/issues/1873
+        match = pathmap.find_paths(path=source_path, index=from_classes_index)
+
         if not match:
-            return
+            normalized_path = jvm_lang.get_normalized_path(
+                path=to_resource.path, extension=extension
+            )
+            match = pathmap.find_paths(path=normalized_path, index=from_classes_index)
+            if not match:
+                return
 
         for resource_id in match.resource_ids:
             from_resource = from_resources.get(id=resource_id)

--- a/scanpipe/pipes/jvm.py
+++ b/scanpipe/pipes/jvm.py
@@ -140,10 +140,25 @@ class JvmLanguage:
         # https://github.com/aboutcode-org/scancode.io/issues/1994
         if class_name.endswith("_$logger.class"):
             class_name, _, _ = class_name.partition("_$logger.class")
-        elif "$" in class_name:  # inner class
+        elif "$" in class_name and not class_name.startswith("$"):  # inner class
             class_name, _, _ = class_name.partition("$")
         else:
             class_name, _, _ = class_name.partition(".")  # plain .class
+        return str(path.parent / f"{class_name}{extension}")
+
+    @classmethod
+    def get_source_path(cls, path, extension):
+        """
+        Return a JVM file path for ``path`` .class file path string.
+        No normalization is performed.
+        """
+        if not path.endswith(cls.binary_extensions):
+            raise ValueError(
+                f"Only path ending with {cls.binary_extensions} are supported."
+            )
+        path = Path(path.strip("/"))
+        class_name = path.name
+        class_name, _, _ = class_name.partition(".")  # plain .class
         return str(path.parent / f"{class_name}{extension}")
 
 

--- a/scanpipe/tests/pipes/test_jvm.py
+++ b/scanpipe/tests/pipes/test_jvm.py
@@ -84,6 +84,16 @@ class ScanPipeJvmTest(TestCase):
         package = jvm.JavaLanguage.get_source_package(input_location)
         self.assertIsNone(package)
 
+    def test_scanpipe_pipes_jvm_get_source_java_path(self):
+        njp = jvm.JavaLanguage.get_source_path("foo/org/common/Bar.class", ".java")
+        self.assertEqual("foo/org/common/Bar.java", njp)
+
+    def test_scanpipe_pipes_jvm_get_source_java_path_with_inner_class(self):
+        njp = jvm.JavaLanguage.get_source_path(
+            "foo/org/common/Bar$inner.class", ".java"
+        )
+        self.assertEqual("foo/org/common/Bar$inner.java", njp)
+
     def test_scanpipe_pipes_jvm_get_normalized_java_path(self):
         njp = jvm.JavaLanguage.get_normalized_path("foo/org/common/Bar.class", ".java")
         self.assertEqual("foo/org/common/Bar.java", njp)


### PR DESCRIPTION
Ref #1873 

The `ConnectorLogger_$logger.class` and `$Module.class` is now correctly mapped.

`ConnectorLogger_$logger.class`
------------------------------------
<img width="1848" height="185" alt="Screenshot 2025-12-15 145613" src="https://github.com/user-attachments/assets/f95c1703-3450-49ff-9d43-2f9d357f6f5a" />
<img width="1109" height="211" alt="Screenshot 2025-12-15 145622" src="https://github.com/user-attachments/assets/c6f2b16d-ce4d-47a5-936d-016fee972c20" />

`$Module.class`
-----------------
<img width="1846" height="279" alt="Screenshot 2025-12-15 145511" src="https://github.com/user-attachments/assets/4f3fffb8-e530-4293-9b65-8de46bd4bc9f" />
<img width="1121" height="213" alt="Screenshot 2025-12-15 145522" src="https://github.com/user-attachments/assets/2747c855-7372-45f5-9a87-ede0f2e8dc52" />
