### PR TITLE
fix: Sanitize ORT package IDs to handle colons in versions

### DIFF
--- a/scanpipe/pipes/ort.py
+++ b/scanpipe/pipes/ort.py
@@ -130,14 +130,28 @@ def get_ort_project_type(project):
         return "docker"
 
 
+def sanitize_id_part(value):
+    """
+    Sanitize an identifier part by replacing colons with underscores.
+    ORT uses colons as separators in the identifier string representation.
+    """
+    if value:
+        return value.replace(":", "_")
+    return value
+
+
 def to_ort_package_list_yml(project):
     """Convert a project object into a YAML string in the ORT package list format."""
     project_type = get_ort_project_type(project)
 
     dependencies = []
     for package in project.discoveredpackages.all():
+        type_ = sanitize_id_part(project_type or package.type)
+        name = sanitize_id_part(package.name)
+        version = sanitize_id_part(package.version)
+
         dependency = Dependency(
-            id=f"{project_type or package.type}::{package.name}:{package.version}",
+            id=f"{type_}::{name}:{version}",
             purl=package.purl,
             sourceArtifact=SourceArtifact(url=package.download_url),
             declaredLicenses=[package.get_declared_license_expression_spdx()],

--- a/scanpipe/tests/pipes/test_ort.py
+++ b/scanpipe/tests/pipes/test_ort.py
@@ -72,3 +72,21 @@ class ScanPipeORTPipesTest(TestCase):
             ],
         }
         self.assertEqual(expected, package_list)
+
+    def test_scanpipe_ort_pipes_to_ort_package_list_yml_sanitization(self):
+        project = make_project(name="Analysis")
+        package_data = {
+            "name": "passwd",
+            "type": "deb",
+            "version": "1:4.13+dfsg1-4ubuntu3.2",
+            "purl": "pkg:deb/ubuntu/passwd@1:4.13%2Bdfsg1-4ubuntu3.2?arch=amd64",
+        }
+        pipes.update_or_create_package(project, package_data)
+
+        package_list_yml = ort.to_ort_package_list_yml(project)
+        package_list = saneyaml.load(package_list_yml)
+        dependency_id = package_list["dependencies"][0]["id"]
+
+        # The colon in the version should be sanitized
+        self.assertNotIn("1:4.13", dependency_id)
+        self.assertEqual("deb::passwd:1_4.13+dfsg1-4ubuntu3.2", dependency_id)


### PR DESCRIPTION
ORT uses colons as separators in identifiers. Package versions containing colons (e.g. Debian epochs) were breaking the identifier format. This change replaces colons with underscores in the ID components.

closes #2004 