### PR TITLE
Do not match .DS_Store files in d2d pipeline

### DIFF
--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -625,7 +625,7 @@ def match_purldb_resources(
         .to_codebase()
         .no_status()
         .has_value("sha1")
-        .exclude(path__endswith="/.DS_Store")
+        .exclude(name=".DS_Store")
         .filter(extension__in=extensions)
     )
     resource_count = to_resources.count()


### PR DESCRIPTION
Fixes #1874

`.DS_Store` files are macOS metadata files and should not be considered for
matching during the d2d pipeline. This change excludes `.DS_Store` resources
from the list of codebase files sent for PurlDB matching.
