### PR TITLE
Fix #1377: Include release field in RPM package version string

### DIFF
--- a/scanpipe/pipes/rootfs.py
+++ b/scanpipe/pipes/rootfs.py
@@ -208,7 +208,15 @@ def package_getter(root_dir, **kwargs):
 
 def _create_system_package(project, purl, package):
     """Create system package and related resources."""
-    created_package = pipes.update_or_create_package(project, package.to_dict())
+    package_data = package.to_dict()
+    
+    if package.type == 'rpm' and hasattr(package, 'release') and package.release:
+        version = package.version or ''
+        release = package.release or ''
+        if version and release:
+            package_data['version'] = f"{version}-{release}"
+    
+    created_package = pipes.update_or_create_package(project, package_data)
 
     installed_files = []
     if hasattr(package, "resources"):


### PR DESCRIPTION
## Problem
RPM packages were showing incomplete version strings in container image scans. The release field was being dropped, causing versions like `4.4.20-4.e18_6` to appear as just `4.4.20`.

## Solution
Modified the `_create_system_package()` function in `scanpipe/pipes/rootfs.py` to combine the RPM `version` and `release` fields with a hyphen before creating the package.

## Changes
- Check if package type is 'rpm' and has a release field
- Combine version and release as `version-release`
- Update package_data before passing to `update_or_create_package()`

## Example
**Before:** `pkg:rpm/bash@4.4.20?arch=x86_64`
**After:** `pkg:rpm/bash@4.4.20-4.e18_6?arch=x86_64`

Fixes #1377