### PR TITLE
Update jvm.py

### DIFF
--- a/scanpipe/pipes/jvm.py
+++ b/scanpipe/pipes/jvm.py
@@ -169,7 +169,8 @@ def find_expression(lines, regex):
 
         >>> lines = ["   package    foo.back ;  # dsasdasdasdasdasda.asdasdasd"]
         >>> regex = java_package_re
-        >>> assert find_expression(lines, regex) == "foo.back"
+        >>> find_expression(lines, regex) 
+    'foo.back'
     """
     for ln, line in enumerate(lines):
         # only look at the first 500 lines


### PR DESCRIPTION
Replaced an assert-based docstring example with a direct function call output example to avoid using assert outside tests.
