### PR TITLE
Fix docker-compose failure for unprivileged users by avoiding /etc host bind mount

### DIFF
--- a/docker-compose-offline.yml
+++ b/docker-compose-offline.yml
@@ -26,7 +26,7 @@ services:
     expose:
       - 8000
     volumes:
-      - /etc/scancodeio/:/etc/scancodeio/
+      - ./etc/scancodeio:/etc/scancodeio
       - workspace:/var/scancodeio/workspace/
       - static:/var/scancodeio/static/
     depends_on:
@@ -42,7 +42,7 @@ services:
     env_file:
       - docker.env
     volumes:
-      - /etc/scancodeio/:/etc/scancodeio/
+      - ./etc/scancodeio:/etc/scancodeio
       - workspace:/var/scancodeio/workspace/
     depends_on:
       - redis

--- a/docker-compose.purldb-scan-worker.yml
+++ b/docker-compose.purldb-scan-worker.yml
@@ -11,7 +11,7 @@ services:
       - docker.env
     volumes:
       - .env:/opt/scancodeio/.env
-      - /etc/scancodeio/:/etc/scancodeio/
+      - ./etc/scancodeio:/etc/scancodeio
       - workspace:/var/scancodeio/workspace/
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       - 8000
     volumes:
       - .env:/opt/scancodeio/.env
-      - /etc/scancodeio/:/etc/scancodeio/
+      - ./etc/scancodeio:/etc/scancodeio
       - workspace:/var/scancodeio/workspace/
       - static:/var/scancodeio/static/
     depends_on:
@@ -138,7 +138,7 @@ services:
       - docker.env
     volumes:
       - .env:/opt/scancodeio/.env
-      - /etc/scancodeio/:/etc/scancodeio/
+      - ./etc/scancodeio:/etc/scancodeio
       - workspace:/var/scancodeio/workspace/
     depends_on:
       - redis


### PR DESCRIPTION
The current docker-compose files bind-mount /etc/scancodeio from the host, which fails for unprivileged users unless the directory is created as root.
This change replaces the absolute host path with a project-local directory (./etc/scancodeio), allowing Docker/Podman to auto-create the directory while preserving the expected /etc/scancodeio path inside the container.

Fixes #1641.
