### PR TITLE
docs: Add Windows troubleshooting for port 80 conflicts

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -572,6 +572,21 @@ Run the App
     docker compose build
     docker compose up
 
+.. warning:: **Windows Users: Port 80 Conflicts**
+
+    If you encounter a **502 Bad Gateway** error or see an **EDB Postgres** page, you likely have a local service blocking port 80.
+
+    To fix this, edit ``docker-compose.yml`` and change the Nginx port mapping:
+
+    .. code-block:: yaml
+
+        nginx:
+          ports:
+            - "9000:80"
+
+    Then access the dashboard at http://localhost:9000
+
 At this stage, the ScanCode.io app is up and running.
 To access the app, open the "PORTS" window and open the address for port 80 in your
 browser.
+


### PR DESCRIPTION
## Description
I encountered a setup issue on Windows 11 where port 80 was occupied by a local EDB Postgres service, preventing the dashboard from loading.

I added a warning to the "Installation" docs with a fix (mapping Nginx to port 9000). This addresses the documentation request in Issue #1842.

## Related Issue
Fixes #1842

## Checklist
- [x] I have signed my commits (DCO)
- [x] Documentation is updated