### PR TITLE
 Fix spelling typos in docs, models, and pipes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1187,7 +1187,7 @@ to be updated for the new ``app`` user, using:
 v32.4.0 (2023-07-13)
 --------------------
 
-- Add support for license policies and complaince alert for Discovered Packages.
+- Add support for license policies and compliance alert for Discovered Packages.
   https://github.com/nexB/scancode.io/issues/151
 
 - Refine the details views and tabs:
@@ -1617,7 +1617,7 @@ v30.2.0 (2021-12-17)
 --------------------
 
 - Add authentication for the Web UI views and REST API endpoint.
-  The autentication is disabled by default and can be enabled using the
+  The authentication is disabled by default and can be enabled using the
   SCANCODEIO_REQUIRE_AUTHENTICATION settings.
   When enabled, users have to authenticate through a login form in the Web UI, or using
   their API Key in the REST API.
@@ -1670,7 +1670,7 @@ v30.1.0 (2021-11-22)
   during the next maintenance tasks.
   QUEUED pipeline will be restored in the queue as the worker redis cache backend data
   is now persistent and reloaded on starting the image.
-  Note that internaly, a running job emits a "heartbeat" every 60 seconds to let all the
+  Note that internally, a running job emits a "heartbeat" every 60 seconds to let all the
   workers know that it is properly running.
   After 90 seconds without any heartbeats, a worker will determine that the job is not
   active anymore and that job will be moved to the failed registry during the worker

--- a/docs/built-in-pipelines.rst
+++ b/docs/built-in-pipelines.rst
@@ -24,7 +24,7 @@ Pipeline Base Class
 
 .. _pipeline_analyze_docker_image:
 
-Analyse Docker Image
+Analyze Docker Image
 --------------------
 .. autoclass:: scanpipe.pipelines.analyze_docker.Docker()
     :members:
@@ -40,7 +40,7 @@ Analyze Root Filesystem or VM Image
 
 .. _analyze_windows_docker_image:
 
-Analyse Docker Windows Image
+Analyze Docker Windows Image
 ----------------------------
 .. autoclass:: scanpipe.pipelines.analyze_docker_windows.DockerWindows()
     :members:

--- a/docs/distros-os-images.rst
+++ b/docs/distros-os-images.rst
@@ -9,7 +9,7 @@ Archives Formats
 ScanCode.io recognizes and **can extract most archive formats**; however, it offers
 special support for VM and container image formats:
 
-- **Docker image tarbal** archives using a Docker image layout
+- **Docker image tarball** archives using a Docker image layout
 - **Virtual machine images** using **QCOW** and **VHDI** image format
 
 Operating Systems Detection
@@ -53,7 +53,7 @@ their license metadata, and their installed files.
   :ref:`analyze_docker_image <pipeline_analyze_docker_image>` pipeline; package and
   license metadata are also detected.
   However, some work needs to be done to achieve comprehensive support and fix
-  the issue of system packages ot tracking their installed files. Check `this
+  the issue of system packages not tracking their installed files. Check `this
   open GitHub issue <https://github.com/GoogleContainerTools/distroless/issues/741>`_
   for more details.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -16,7 +16,7 @@ and run the appropriate pipeline.
 ScanCode.io offers several :ref:`built_in_pipelines` depending on your input, see
 the :ref:`faq_which_pipeline` below.
 
-As an alternative, If you simply which to run a pipeline without installing ScanCode.io
+As an alternative, If you simply wish to run a pipeline without installing ScanCode.io
 you may use the Docker image to run pipelines as a single command:
 
 .. code-block:: bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -156,7 +156,7 @@ and **build the Docker image**::
 .. warning::
     The Docker image has been updated to run as a non-root user.
     If you encounter "permissions" issues while running the ScanCode.io Docker images
-    following the ``docker compose build``, you will need to update the the permissions
+    following the ``docker compose build``, you will need to update the permissions
     of the ``/var/scancodeio/`` directory of the Docker volumes using::
 
         docker compose run -u 0:0 web chown -R app:app /var/scancodeio/

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -98,7 +98,7 @@ The second essential part of ScanCode.io is the **ScanCode Toolkit**, which is u
 for archives extraction and as the scanning engine.
 
 The nexB `container-inspector <https://github.com/aboutcode-org/container-inspector>`_ library
-is also a key component of ScanCode.io as this tool is used to analyse Docker
+is also a key component of ScanCode.io as this tool is used to analyze Docker
 images, containers, root filesystems, and virtual machine images.
 
 .. note::

--- a/docs/output-files.rst
+++ b/docs/output-files.rst
@@ -215,7 +215,7 @@ similar to the following:
       }
     ]
 
-The results will also include all of the  or files (codebase resources) found.
+The results will also include all of the files (codebase resources) found.
 
 .. note::
     Please note that these files might or might not be included within a package.

--- a/docs/tutorial_api_analyze_package_archive.rst
+++ b/docs/tutorial_api_analyze_package_archive.rst
@@ -1,6 +1,6 @@
 .. _tutorial_api_analyze_package_archive:
 
-Analyse Package Archive (REST API)
+Analyze Package Archive (REST API)
 ==================================
 
 This tutorial complements the :ref:`rest_api` section, and the aim here is to

--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -3650,7 +3650,7 @@ class AbstractPackage(models.Model):
         blank=True,
         help_text=_(
             "A list of Resource paths for package datafiles which were "
-            "used to assemble this pacakage."
+            "used to assemble this package."
         ),
     )
     file_references = models.JSONField(
@@ -4448,7 +4448,7 @@ class DiscoveredLicenseQuerySet(
         return self.filter(needs_review=False)
 
     def order_by_count_and_expression(self):
-        """Order by detection count and license expression (identifer) fields."""
+        """Order by detection count and license expression (identifier) fields."""
         return self.order_by("-detection_count", "identifier")
 
 
@@ -4565,8 +4565,8 @@ class DiscoveredLicense(
         blank=True,
         help_text=_(
             "A list of review comments for license detection issues which "
-            "needs review. These descriptive comments are based on ambigous "
-            "detection types and could also offers helpful suggestions on "
+            "needs review. These descriptive comments are based on ambiguous "
+            "detection types and could also offer helpful suggestions on "
             "how to review/report these detection issues."
         ),
     )

--- a/scanpipe/pipelines/__init__.py
+++ b/scanpipe/pipelines/__init__.py
@@ -232,7 +232,7 @@ class ProjectPipeline(CommonStepsMixin, BasePipeline):
 
             for resource in self.project.codebaseresources.all():
                 with self.save_errors(Exception, resource=resource):
-                    analyse(resource)
+                    analyze(resource)
         """
         try:
             yield

--- a/scanpipe/pipes/__init__.py
+++ b/scanpipe/pipes/__init__.py
@@ -341,7 +341,7 @@ def update_or_create_license_detection(
     Use the `project` and `detection_data` mapping to lookup and creates the
     DiscoveredLicense using its detection identifier as a unique key.
 
-    Additonally if `resource_path` is passed, add the file region where
+    Additionally if `resource_path` is passed, add the file region where
     the license was detected to the DiscoveredLicense object, if not present
     already. `from_package` is True if the license detection was in a
     `extracted_license_statement` from a package metadata.

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -461,7 +461,7 @@ def get_project_resources_qs(project, resources):
             # intend to. For example, if we have matched on the directory with
             # the path `foo/bar/1`, using the __startswith filter without
             # including a trailing slash on the path would have us get all
-            # diretories under `foo/bar/` that start with 1, such as
+            # directories under `foo/bar/` that start with 1, such as
             # `foo/bar/10001`, `foo/bar/123`, etc., when we just want `foo/bar/1`
             # and its descendants.
             path = f"{resource.path}/"
@@ -595,7 +595,7 @@ def match_sha1s_to_purldb(
 ):
     """
     Process `resources_by_sha1` with `matcher_func` and return a 3-tuple
-    contaning an empty defaultdict(list), the number of matches and the number
+    containing an empty defaultdict(list), the number of matches and the number
     of sha1s sent to purldb.
     """
     matched_count = matcher_func(

--- a/scanpipe/pipes/d2d_config.py
+++ b/scanpipe/pipes/d2d_config.py
@@ -60,7 +60,7 @@ class EcosystemConfig:
     # which are not so useful in mapping
     standard_symbols_to_exclude: list = field(default_factory=list)
 
-    # File extesions which should be looked at for source symbol extraction
+    # File extensions which should be looked at for source symbol extraction
     # for mapping using symbols for a specific selected option/ecosystem
     source_symbol_extensions: list = field(default_factory=list)
 

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -834,7 +834,7 @@ def match_and_resolve_dependencies(project):
             )
 
     # We need only the direct dependency relationships but not the from indirect
-    # dependency realtionships which are between the main package to resolved packages
+    # dependency relationships which are between the main package to resolved packages
     indirect_dependencies = project.discovereddependencies.filter(is_direct=False)
     indirect_dependencies.delete()
 

--- a/scanpipe/pipes/symbolmap.py
+++ b/scanpipe/pipes/symbolmap.py
@@ -62,7 +62,7 @@ class SymbolsMatchResult:
     Statistics and debug information for each attempted matching
     between a binary and a source file using extracted symbols.
     Contains CodebaseRelation and other data to create the codebase
-    realtions optionally if matching with symbols is successful.
+    relations optionally if matching with symbols is successful.
     """
 
     from_resource: str

--- a/scanpipe/tests/pipes/test_scancode.py
+++ b/scanpipe/tests/pipes/test_scancode.py
@@ -478,7 +478,7 @@ class ScanPipeScancodePipesTest(TestCase):
         uuid = "ba110d49-b6f2-4c86-8d89-a6fd34838ca8"
         package.update(package_uid=f"pkg:npm/is-npm@1.0.0?uuid={uuid}")
 
-        # Patching the ``file_type`` and ``mime_typea` values as those are OS dependant.
+        # Patching the ``file_type`` and ``mime_type`` values as those are OS dependent.
         # Note that we cannot use proper ``mock`` as the ``scan_package`` pipeline
         # uses a subprocess call to run the ``scancode`` command.
         project1.codebaseresources.all().update(file_type="", mime_type="text/plain")

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -1204,7 +1204,7 @@ class ScanPipeModelsTest(TestCase):
         self.assertEqual(0, run1.task_exitcode)
         self.assertEqual("output", run1.task_output)
         self.assertTrue(run1.task_end_date)
-        # Ensure the initial value for `log` was not overriden during the
+        # Ensure the initial value for `log` was not overridden during the
         # `set_task_ended.save()`
         self.assertIn("entry in log", run1.log)
 

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -526,7 +526,7 @@ class PipelinesIntegrationTest(TestCase):
         "created_date",
         "log",
         "uuid",
-        "size",  # directory sizes are OS dependant
+        "size",  # directory sizes are OS dependent
         "size_count",
         "--json-pp",
         "--processes",


### PR DESCRIPTION
## Summary           
Spelling typos found using [`codespell`](https://github.com/codespell-project/codespell) and fixed manually across 18 files (26 corrections).                    
  ### Scope                                                                                                                                                     
  
  - **Docs:** `CHANGELOG.rst`, `built-in-pipelines.rst`, `distros-os-images.rst`, `faq.rst`, `installation.rst`, `introduction.rst`, `output-files.rst`,        
  `tutorial_api_analyze_package_archive.rst`
  - **Source:** `models.py`, `pipelines/__init__.py`, `pipes/__init__.py`, `pipes/d2d.py`, `pipes/d2d_config.py`, `pipes/scancode.py`, `pipes/symbolmap.py`     
  - **Tests:** `test_scancode.py`, `test_models.py`, `test_pipelines.py`

  All changes are limited to comments, docstrings, help text, and documentation. No functional code changes.

  Full list of corrections: https://github.com/aboutcode-org/scancode.io/issues/2045

  Fixes https://github.com/aboutcode-org/scancode.io/issues/2045

  Signed-off-by: Mrityunjay Raj <mr.raj.earth@gmail.com>