### PR TITLE
Rename 'Grammar' optional step group to 'Antlr' in deploy_to_develop …

### DIFF
--- a/scanpipe/pipelines/deploy_to_develop.py
+++ b/scanpipe/pipelines/deploy_to_develop.py
@@ -250,21 +250,21 @@ class DeployToDevelop(Pipeline):
             project=self.project, jvm_lang=jvm.KotlinLanguage, logger=self.log
         )
 
-    @optional_step("Grammar")
+    @optional_step("Antlr")
     def find_grammar_packages(self):
         """Find the java package of the .g/.g4 source files."""
         d2d.find_jvm_packages(
             project=self.project, jvm_lang=jvm.GrammarLanguage, logger=self.log
         )
 
-    @optional_step("Grammar")
+    @optional_step("Antlr")
     def map_grammar_to_class(self):
         """Map a .class compiled file to its .g/.g4 source."""
         d2d.map_jvm_to_class(
             project=self.project, jvm_lang=jvm.GrammarLanguage, logger=self.log
         )
 
-    @optional_step("Grammar")
+    @optional_step("Antlr")
     def map_jar_to_grammar_source(self):
         """Map .jar files to their related source directory."""
         d2d.map_jar_to_jvm_source(


### PR DESCRIPTION
Fixes #2057

Rename the optional step group from **"Grammar"** to **"Antlr"** in the `develop_to_deploy` pipeline to remove ambiguity and align with other technology-specific group names.

This affects three ANTLR-related steps handling `.g/.g4` files:

* `find_grammar_packages`
* `map_grammar_to_class`
* `map_jar_to_grammar_source`

Internal identifiers (e.g., `GrammarLanguage`, database keys) are intentionally unchanged to avoid migrations.

**Note:** Existing configs or API calls using `--groups Grammar` must be updated to `--groups Antlr`.
