### PR TITLE
Fix #1980: Centralize output format definitions and sync run command with print-safe formats

### DIFF
--- a/scanpipe/management/commands/output.py
+++ b/scanpipe/management/commands/output.py
@@ -24,16 +24,7 @@ from django.core.management.base import CommandError
 
 from scanpipe.management.commands import ProjectCommand
 from scanpipe.pipes import output
-
-SUPPORTED_FORMATS = [
-    "json",
-    "csv",
-    "xlsx",
-    "attribution",
-    "spdx",
-    "cyclonedx",
-    "ort-package-list",
-]
+from scanpipe.pipes.output import SUPPORTED_FORMATS
 
 
 class Command(ProjectCommand):

--- a/scanpipe/management/commands/run.py
+++ b/scanpipe/management/commands/run.py
@@ -30,6 +30,7 @@ from django.utils.crypto import get_random_string
 
 from scanpipe.management.commands import extract_tag_from_input_file
 from scanpipe.pipes.fetch import SCHEME_TO_FETCHER_MAPPING
+from scanpipe.pipes.output import PRINT_SUPPORTED_FORMATS
 
 
 class Command(BaseCommand):
@@ -59,7 +60,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--format",
             default="json",
-            choices=["json", "spdx", "cyclonedx", "attribution", "ort-package-list"],
+            choices=PRINT_SUPPORTED_FORMATS,
             help="Specifies the output serialization format for the results.",
         )
 

--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -68,6 +68,27 @@ from scanpipe.pipes import spdx
 
 scanpipe_app = apps.get_app_config("scanpipe")
 
+# All formats supported by the `output` management command.
+SUPPORTED_FORMATS = [
+    "json",
+    "csv",
+    "xlsx",
+    "attribution",
+    "spdx",
+    "cyclonedx",
+    "ort-package-list",
+]
+
+# Subset of formats compatible with stdout streaming (--print mode).
+# Excludes binary formats (xlsx) and multi-file formats (csv).
+PRINT_SUPPORTED_FORMATS = [
+    "json",
+    "spdx",
+    "cyclonedx",
+    "attribution",
+    "ort-package-list",
+]
+
 
 def safe_filename(filename):
     """Convert the provided `filename` to a safe filename."""

--- a/scanpipe/tests/test_commands.py
+++ b/scanpipe/tests/test_commands.py
@@ -48,6 +48,8 @@ from scanpipe.models import Run
 from scanpipe.models import WebhookSubscription
 from scanpipe.pipes import flag
 from scanpipe.pipes import purldb
+from scanpipe.pipes.output import PRINT_SUPPORTED_FORMATS
+from scanpipe.pipes.output import SUPPORTED_FORMATS as PIPE_SUPPORTED_FORMATS
 from scanpipe.tests import filter_warnings
 from scanpipe.tests import make_dependency
 from scanpipe.tests import make_mock_response
@@ -756,6 +758,29 @@ class ScanPipeManagementCommandTest(TestCase):
         self.assertIn('"bomFormat": "CycloneDX"', out_value)
         self.assertIn('"specVersion": "1.5",', out_value)
 
+    def test_supported_formats_sync(self):
+        """
+        Ensure SUPPORTED_FORMATS in management/commands/output.py always matches
+        the canonical list in pipes/output.py, and that PRINT_SUPPORTED_FORMATS
+        is a strict subset of SUPPORTED_FORMATS (never includes csv or xlsx).
+        """
+        from scanpipe.management.commands.output import SUPPORTED_FORMATS as CMD_FORMATS
+
+        self.assertEqual(
+            set(PIPE_SUPPORTED_FORMATS),
+            set(CMD_FORMATS),
+            "SUPPORTED_FORMATS in management/commands/output.py is out of sync "
+            "with pipes/output.py. Update one of them.",
+        )
+        # PRINT_SUPPORTED_FORMATS must be a subset of SUPPORTED_FORMATS
+        self.assertTrue(
+            set(PRINT_SUPPORTED_FORMATS).issubset(set(PIPE_SUPPORTED_FORMATS)),
+            "PRINT_SUPPORTED_FORMATS contains formats not in SUPPORTED_FORMATS.",
+        )
+        # csv and xlsx must never be in PRINT_SUPPORTED_FORMATS (--print incompatible)
+        self.assertNotIn("csv", PRINT_SUPPORTED_FORMATS)
+        self.assertNotIn("xlsx", PRINT_SUPPORTED_FORMATS)
+
     def test_scanpipe_management_command_delete_project(self):
         project = make_project(name="my_project")
         work_path = project.work_path
@@ -983,6 +1008,31 @@ class ScanPipeManagementCommandTest(TestCase):
 
         json_data = json.loads(out.getvalue())
         self.assertEqual(3, len(json_data["files"]))
+
+        # Test --format spdx
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("run", "do_nothing", input_location, "--format", "spdx")
+        out_value = out.getvalue()
+        self.assertIn('"spdxVersion":', out_value)
+
+        # Test --format cyclonedx
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("run", "do_nothing", input_location, "--format", "cyclonedx")
+        out_value = out.getvalue()
+        self.assertIn('"bomFormat": "CycloneDX"', out_value)
+
+        # Test --format ort-package-list
+        # do_nothing pipeline doesn't find packages, so it generates an empty list, but it shouldn't crash
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("run", "do_nothing", input_location, "--format", "ort-package-list")
+        
+        # Test incompatible streaming formats are rejected by argparse choices
+        expected = "Error: argument --format: invalid choice: 'csv'"
+        with self.assertRaisesMessage(CommandError, expected):
+            call_command("run", "do_nothing", input_location, "--format", "csv")
 
         # Multiple pipeline and selected_groups are supported
         out = StringIO()


### PR DESCRIPTION
<p data-start="176" data-end="300">Fixes #1980 by removing duplicated output format definitions and introducing a single source of truth for supported formats.</p>
<p data-start="302" data-end="625">The <code data-start="306" data-end="311">run</code> command previously relied on a hardcoded list of formats, which could fall out of sync when new formats (e.g. <code data-start="422" data-end="440">ort-package-list</code>) were added to the <code data-start="460" data-end="468">output</code> command. Since <code data-start="484" data-end="489">run</code> internally uses stdout streaming (<code data-start="524" data-end="533">--print</code>), it must restrict formats to those compatible with streaming (excluding <code data-start="607" data-end="612">csv</code> and <code data-start="617" data-end="623">xlsx</code>).</p>
<p data-start="627" data-end="773">This PR centralizes format definitions and ensures both commands remain synchronized while preserving the safety constraints of the <code data-start="759" data-end="764">run</code> command.</p>
<hr data-start="775" data-end="778">
<h2 data-start="780" data-end="790">Changes</h2>
<ul data-start="792" data-end="1390">
<li data-start="792" data-end="994">
<p data-start="794" data-end="850">Added canonical constants in <code data-start="823" data-end="849">scanpipe/pipes/output.py</code>:</p>
<ul data-start="853" data-end="994">
<li data-start="853" data-end="922">
<p data-start="855" data-end="922"><code data-start="855" data-end="874">SUPPORTED_FORMATS</code> — all formats supported by the <code data-start="906" data-end="914">output</code> command</p>
</li>
<li data-start="925" data-end="994">
<p data-start="927" data-end="994"><code data-start="927" data-end="952">PRINT_SUPPORTED_FORMATS</code> — subset compatible with stdout streaming</p>
</li>
</ul>
</li>
<li data-start="995" data-end="1076">
<p data-start="997" data-end="1076">Updated <code data-start="1005" data-end="1045">scanpipe/management/commands/output.py</code> to import <code data-start="1056" data-end="1075">SUPPORTED_FORMATS</code>.</p>
</li>
<li data-start="1077" data-end="1186">
<p data-start="1079" data-end="1186">Updated <code data-start="1087" data-end="1124">scanpipe/management/commands/run.py</code> to use <code data-start="1132" data-end="1157">PRINT_SUPPORTED_FORMATS</code> instead of a hardcoded list.</p>
</li>
<li data-start="1187" data-end="1390">
<p data-start="1189" data-end="1222">Added regression tests to ensure:</p>
<ul data-start="1225" data-end="1390">
<li data-start="1225" data-end="1257">
<p data-start="1227" data-end="1257">Format lists stay synchronized</p>
</li>
<li data-start="1260" data-end="1334">
<p data-start="1262" data-end="1334"><code data-start="1262" data-end="1287">PRINT_SUPPORTED_FORMATS</code> remains a strict subset of <code data-start="1315" data-end="1334">SUPPORTED_FORMATS</code></p>
</li>
<li data-start="1337" data-end="1390">
<p data-start="1339" data-end="1390">Incompatible formats are rejected early by argparse</p>
</li>
</ul>
</li>
</ul>
<hr data-start="1392" data-end="1395">
<h2 data-start="1397" data-end="1408">Behavior</h2>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
Command | Before | After
<h2 data-start="265" data-end="276">Behavior</h2>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
## Behavior

| Command | Before | After |
|---------|--------|-------|
`run --format spdx` | ✅ Worked | ✅ Works |
`run --format cyclonedx` | ✅ Worked | ✅ Works |
`run --format ort-package-list` | ❌ Could fall out of sync | ✅ Works |
`run --format csv` | ⚠️ Could crash (not print-safe) | ❌ Rejected early |
`run --format xlsx` | ⚠️ Could crash (binary) | ❌ Rejected early |
`output --format csv` | ✅ Worked | ✅ Works |
`output --format xlsx` | ✅ Worked | ✅ Works |

</div></div>
<hr data-start="1863" data-end="1866">
<h2 data-start="1868" data-end="1877">Result</h2>
<ul data-start="1879" data-end="2119">
<li data-start="1879" data-end="1947">
<p data-start="1881" data-end="1947"><code data-start="1881" data-end="1886">run</code> automatically supports newly added print-compatible formats.</p>
</li>
<li data-start="1948" data-end="2008">
<p data-start="1950" data-end="2008">Incompatible formats are safely rejected before execution.</p>
</li>
<li data-start="2009" data-end="2090">
<p data-start="2011" data-end="2090">Eliminates duplicated configuration and prevents future drift between commands.</p>
</li>
<li data-start="2091" data-end="2119">
<p data-start="2093" data-end="2119">No behavioral regressions.</p></li></ul>