### PR TITLE
Add path exclusions for PyPI to reduce deployment noise

### DIFF
--- a/scanpipe/pipes/d2d_config.py
+++ b/scanpipe/pipes/d2d_config.py
@@ -183,6 +183,18 @@ ECOSYSTEM_CONFIGS = {
         ecosystem_option="Python",
         source_symbol_extensions=[".pyx", ".pxd", ".py", ".pyi"],
         matchable_resource_extensions=[".py", ".pyi"],
+        deployed_resource_path_exclusions=[
+            "*.cmake",
+            "*.mo",
+            "*.toml",
+            "*.txt",
+            "*.db",
+            "*.conf",
+            "*.pth",
+            "*.dist-info/*",
+            "*.pc",
+            "*.la",
+        ],
     ),
 }
 


### PR DESCRIPTION
 Fixes #1846

 by adding deployed_resource_path_exclusions to the Python ecosystem config in scanpipe/pipes/d2d_config.py

During the map_deploy_to_develop pipeline, standard PyPI files (like *.toml, *.cmake, *.dist-info/*, etc.) were being incorrectly flagged as "requires-review". This PR explicitly ignores these files during deployment mapping, drastically reducing false positives and review noise. Tested locally with scanpipe.tests.pipes.test_d2d.