### PR TITLE
Automate releases using python-semantic-release 

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,22 @@
+name: Commit Message Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+jobs:
+  commit-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install commitizen
+        run: pip install commitizen
+
+      - name: Validate commit messages
+        run: |
+          cz check --rev-range origin/main..HEAD
+          

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,39 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    if: github.repository == 'aboutcode-org/scancode.io'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install release dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build python-semantic-release
+
+      - name: Run Semantic Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release publish

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,31 +1,39 @@
 # Release instructions for `ScanCode.io`
 
-### Automated release workflow
+## 🚀 Automated Release Workflow
 
-- Create a new `release-x.x.x` branch
-- Update the version in:
-  - `pyproject.toml`
-  - `scancodeio/__init__.py`
-  - `CHANGELOG.rst` (set date)
-- Commit and push this branch
-- Create a PR and merge once approved
-- Tag and push that tag. This will trigger the `pypi-release.yml` GitHub workflow that 
-  takes care of building the dist release files and upload those to pypi:
-  ```
-  VERSION=vx.x.x  # <- Set the new version here
-  git tag -a $VERSION -m ""
-  git push origin $VERSION
-  ```
-- Review the GitHub release created by the workflow at 
-  https://github.com/aboutcode-org/scancode.io/releases
+Releases are fully automated using **python-semantic-release**.
 
-### Manual build
+When commits following the Conventional Commits specification are merged into the `main` branch:
 
-```
-cd scancode.io
-source .venv/bin/activate
-python -m pip install build
-python -m build --sdist --wheel --outdir dist/ .
-```
+- The next semantic version is computed automatically.
+- `pyproject.toml` and `scancodeio/__init__.py` are updated.
+- `CHANGELOG.rst` is generated/updated automatically.
+- A Git tag is automatically created (vX.Y.Z).
+- The tag triggers the existing PyPI publishing workflow.
+- The PyPI workflow builds distributions and creates the GitHub Release.
 
-The distribution files will be available in the local `dist/` directory.
+No manual version bumping, branching, or tagging is required.
+
+---
+
+## 📌 Commit Message Requirements
+
+Commits must follow the Conventional Commits format:
+
+- `feat: add new feature`
+- `fix: correct issue in pipeline`
+- `feat!: introduce breaking change`
+- `chore: maintenance update`
+
+The commit type determines the version bump:
+
+- `fix` → patch
+- `feat` → minor
+- `feat!` or `BREAKING CHANGE:` → major
+
+---
+
+## 🛠 Manual Build (Optional)
+
+If you need to build distribution files locally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,8 @@ dev = [
   "sphinx-rtd-theme==3.0.2",
   "sphinx-rtd-dark-mode==1.3.0",
   "sphinxcontrib-django==2.5",
+  # Commit convention enforcement
+  "commitizen==3.29.0",
 ]
 android_analysis = [
   "android_inspector==0.0.1"
@@ -201,3 +203,27 @@ max-complexity = 10
 "**/test_spdx.py*" = ["S101"]
 # Allow complexity in management commands
 "scanpipe/management/commands/*" = ["C901"]
+
+[tool.semantic_release]
+commit_parser = "conventional"
+build_command = "python3 -m build"
+upload_to_pypi = false
+upload_to_release = false
+tag_format = "v{version}"
+changelog_file = "CHANGELOG.rst"
+changelog_style = "rst"
+version_variable = [
+  "scancodeio/__init__.py:VERSION"
+]
+version_toml = [
+  "pyproject.toml:project.version"
+]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version_provider = "scm"
+version_files = [
+  "pyproject.toml:project.version",
+  "scancodeio/__init__.py:VERSION"
+]
+tag_format = "v$version"


### PR DESCRIPTION
# Automate Releases using python-semantic-release

Fixes #1992

This PR introduces an automated, CI-driven release workflow using
**python-semantic-release** to remove the remaining manual steps
(version bumping and tagging) from the current release process.

## Technical approach

- Semantic version calculation based on Conventional Commits
- Automatic updates to:
  - `pyproject.toml`
  - `scancodeio/__init__.py`
  - `CHANGELOG.rst`
- Automatic creation of a `vX.Y.Z` Git tag on merge to `main`
- Reuse of the existing PyPI publishing workflow for build and distribution

## Implementation

The goal is to make releases:

- Deterministic and reproducible
- Convention-based rather than manual
- Fully CI-managed
- Backwards-compatible with the existing publishing pipeline

No changes were made to the current PyPI workflow logic — this proposal
strictly automates the versioning and tagging layer.

This implementation is intentionally minimal and scoped, and can be
adjusted (tooling, branching model, changelog behavior) based on
maintainer preference.