### PR TITLE
Bump android_inspector to v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ dev = [
   "sphinxcontrib-django==2.5",
 ]
 android_analysis = [
-  "android_inspector==0.0.1"
+  "android_inspector==0.2.0"
 ]
 mining = [
   "minecode_pipelines==0.1.1"


### PR DESCRIPTION
`android_inspector` v0.0.1 has incorrect entry point https://github.com/aboutcode-org/android-inspector/blob/v0.0.1/setup.cfg#L76