### PR TITLE
Fix crash in assemble_package when manifest is at codebase root

### DIFF
--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -619,16 +619,22 @@ def assemble_package(resource, project, processed_paths):
             package_adder=add_resource_to_package,
         )
 
-        for item in extracted_items:
-            logger.info(f"    Processing item: {item}")
-            if isinstance(item, packagedcode_models.Package):
-                pipes.update_or_create_package(project, item.to_dict())
-            elif isinstance(item, packagedcode_models.Dependency):
-                pipes.update_or_create_dependency(project, item.to_dict())
-            elif isinstance(item, CodebaseResource):
-                processed_paths.add(item.path)
-            else:
-                logger.info(f"Unknown Package assembly item type: {item!r}")
+        try:
+            for item in extracted_items:
+                logger.info(f"    Processing item: {item}")
+                if isinstance(item, packagedcode_models.Package):
+                    pipes.update_or_create_package(project, item.to_dict())
+                elif isinstance(item, packagedcode_models.Dependency):
+                    pipes.update_or_create_dependency(project, item.to_dict())
+                elif isinstance(item, CodebaseResource):
+                    processed_paths.add(item.path)
+                else:
+                    logger.info(f"Unknown Package assembly item type: {item!r}")
+        except AttributeError as e:
+            # Occurs when the handler cannot resolve a parent resource,
+            # e.g. a manifest at the root of the codebase with no parent path.
+            logger.warning(f"  Package assembly skipped for {resource.path}: {e}")
+            logger.debug("", exc_info=True)
 
 
 def process_package_data(project, static_resolve=False):


### PR DESCRIPTION
Fixes the issue reported in : **scancode-action** [#11](https://github.com/aboutcode-org/scancode-action/issues/11)

when a package manifest (e.g. pom.xml) is at the root of the input directory, `assemble_package()` crashes with:

    AttributeError: 'NoneType' object has no attribute 'path'

this happens because packagedcode's maven handler calls `resource.parent()`  which returns **None** when there is no parent path, then passes that **None**  to `assign_package_to_resources()`



### Fix

wrapped `handler.assemble()` in `assemble_package()` with a `try/except AttributeError` so the pipeline logs a warning and continues instead of crashing

### Testing

reproduced and verified locally