### PR TITLE
Improve scan_for_virus robustness and add missing resource test

### DIFF
--- a/scanpipe/pipes/clamav.py
+++ b/scanpipe/pipes/clamav.py
@@ -20,18 +20,22 @@
 # ScanCode.io is a free software code scanning tool from nexB Inc. and others.
 # Visit https://github.com/aboutcode-org/scancode.io for support and download.
 
+import logging
 from pathlib import Path
 
 from django.conf import settings
 
 import clamd
 
+logger = logging.getLogger(__name__)
+
 
 def scan_for_virus(project):
     """
     Run a ClamAV scan to detect virus infection.
-    Create one Project error message per found virus and store the detection data
-    on the related codebase resource ``extra_data`` field.
+    - Avoid crashes when ClamAV reports files not indexed in CodebaseResource.
+    - Avoid per-file DB queries by preloading valid resource paths.
+    - Record a project-level error for any detected virus.
     """
     if settings.CLAMD_USE_TCP:
         clamd_socket = clamd.ClamdNetworkSocket(settings.CLAMD_TCP_ADDR)
@@ -43,17 +47,37 @@ def scan_for_virus(project):
     except clamd.ClamdError as e:
         raise Exception(f"Error with the ClamAV service: {e}")
 
+    # Preload all valid indexed resource paths
+    valid_paths = set(project.codebaseresources.values_list("path", flat=True))
+
+    missing_resources = []
+
     for resource_location, results in scan_response.items():
         status, reason = results
-        resource_path = Path(resource_location).relative_to(project.codebase_path)
 
-        resource = project.codebaseresources.get(path=resource_path)
+        if status != "FOUND":
+            continue
+
+        resource_path = Path(resource_location).relative_to(project.codebase_path)
+        resource_path_str = str(resource_path)
+
+        if resource_path_str not in valid_paths:
+            missing_resources.append(resource_path_str)
+            logger.warning(
+                "ClamAV detected virus in non-indexed file: %s",
+                resource_path_str,
+            )
+            continue
+
+        resource = project.codebaseresources.filter(path=resource_path_str).first()
+
         virus_report = {
-            "calmav": {
+            "clamav": {
                 "status": status,
                 "reason": reason,
             }
         }
+
         resource.update_extra_data({"virus_report": virus_report})
 
         project.add_error(
@@ -62,6 +86,13 @@ def scan_for_virus(project):
             details={
                 "status": status,
                 "reason": reason,
-                "resource_path": str(resource_path),
+                "resource_path": resource_path_str,
             },
+        )
+
+    if missing_resources:
+        project.add_error(
+            description="ClamAV detected virus in files not indexed in DB",
+            model="ScanForVirus",
+            details={"missing_resources": missing_resources},
         )

--- a/scanpipe/tests/pipes/test_clamav.py
+++ b/scanpipe/tests/pipes/test_clamav.py
@@ -37,7 +37,10 @@ class ScanPipeClamAVPipesTest(TestCase):
     def test_scanpipe_pipes_clamav_scan_for_virus(self, mock_multiscan):
         project = Project.objects.create(name="project")
         r1 = make_resource_file(project=project, path="eicar.zip")
-        r2 = make_resource_file(project=project, path="eicar.zip-extract/eicar.com")
+        r2 = make_resource_file(
+            project=project,
+            path="eicar.zip-extract/eicar.com",
+        )
 
         mock_multiscan.return_value = {
             r1.location: ("FOUND", "Win.Test.EICAR_HDB-1"),
@@ -45,11 +48,20 @@ class ScanPipeClamAVPipesTest(TestCase):
         }
 
         clamav.scan_for_virus(project)
+
         self.assertEqual(2, len(project.projectmessages.all()))
+
         error_message = project.projectmessages.all()[0]
         self.assertEqual("error", error_message.severity)
-        self.assertEqual("Virus detected", error_message.description)
-        self.assertEqual("ScanForVirus", error_message.model)
+        self.assertEqual(
+            "Virus detected",
+            error_message.description,
+        )
+        self.assertEqual(
+            "ScanForVirus",
+            error_message.model,
+        )
+
         expected_details = {
             "reason": "Win.Test.EICAR_HDB-1",
             "status": "FOUND",
@@ -60,10 +72,39 @@ class ScanPipeClamAVPipesTest(TestCase):
         resource1 = project.codebaseresources.first()
         expected_virus_report_extra_data = {
             "virus_report": {
-                "calmav": {
+                "clamav": {
                     "status": "FOUND",
                     "reason": "Win.Test.EICAR_HDB-1",
                 }
             }
         }
-        self.assertEqual(expected_virus_report_extra_data, resource1.extra_data)
+        self.assertEqual(
+            expected_virus_report_extra_data,
+            resource1.extra_data,
+        )
+
+    @mock.patch("clamd.ClamdNetworkSocket.multiscan")
+    def test_scanpipe_pipes_clamav_missing_resource_does_not_crash(
+        self, mock_multiscan
+    ):
+        project = Project.objects.create(name="project")
+
+        r1 = make_resource_file(
+            project=project,
+            path="indexed.txt",
+        )
+
+        mock_multiscan.return_value = {
+            r1.location: ("FOUND", "Test.Virus"),
+            str(project.codebase_path / "non_indexed.txt"): (
+                "FOUND",
+                "Test.Virus",
+            ),
+        }
+
+        clamav.scan_for_virus(project)
+
+        self.assertEqual(
+            2,
+            len(project.projectmessages.all()),
+        )


### PR DESCRIPTION
## Issues

- Closes: #2019

## Changes

This improves the robustness of `scan_for_virus` when ClamAV reports files that are not indexed in `CodebaseResource`.

Previously, `.get(path=...)` could raise `DoesNotExist`, causing the pipeline to fail when ClamAV returned a file not present in the database.

This change:

- Avoids exception-driven control flow
- Preloads indexed resource paths to prevent per-file DB lookups
- Safely skips non-indexed infected files
- Preserves existing virus detection behavior
- Fixes typo in extra_data key (`calmav` → `clamav`)
- Adds a regression test covering the missing-resource scenario

## Checklist

- [x] I have read the contributing guidelines
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR