### PR TITLE
Fix #1791: Ignore NuGet metadata files in extracted .nupkg archives

### DIFF
--- a/scanpipe/pipelines/__init__.py
+++ b/scanpipe/pipelines/__init__.py
@@ -77,6 +77,7 @@ class CommonStepsMixin:
         if isinstance(ignored_patterns, str):
             ignored_patterns = ignored_patterns.splitlines()
         ignored_patterns.extend(flag.DEFAULT_IGNORED_PATTERNS)
+        ignored_patterns.extend(flag.NUGET_IGNORED_PATTERNS)
 
         flag.flag_ignored_patterns(
             codebaseresources=self.project.codebaseresources.no_status(),

--- a/scanpipe/pipes/flag.py
+++ b/scanpipe/pipes/flag.py
@@ -77,6 +77,19 @@ DEFAULT_IGNORED_PATTERNS = [
     "*/policies.yml",
     "*/__MACOSX*",  # macOS metadata folder
 ]
+# NuGet ecosystem files that are not useful for analysis when found inside
+# extracted .nupkg archives.
+NUGET_IGNORED_PATTERNS = [
+    "*_rels/.rels",
+    "*Content_Types*.xml",
+    "*package/services/metadata*",
+    "*.signature.p7s",
+    "*.runtimeconfig.json",
+    "*.dll.config",
+    "*.exe.config",
+    "*.shasum",
+    "*.png",
+]
 
 
 def flag_empty_files(project):

--- a/scanpipe/tests/pipes/test_flag.py
+++ b/scanpipe/tests/pipes/test_flag.py
@@ -20,6 +20,8 @@
 # ScanCode.io is a free software code scanning tool from nexB Inc. and others.
 # Visit https://github.com/nexB/scancode.io for support and download.
 
+from fnmatch import fnmatch
+
 from django.test import TestCase
 
 from scanpipe import pipes
@@ -137,3 +139,20 @@ class ScanPipeFlagPipesTest(TestCase):
         self.resource2.refresh_from_db()
         self.assertEqual("mapped", self.resource1.status)
         self.assertEqual("mapped", self.resource2.status)
+
+    def test_nuget_ignored_patterns_match_expected_files(self):
+        paths = [
+            "package/_rels/.rels",
+            "package/[Content_Types].xml",
+            "package/services/metadata/core-properties",
+            "foo.runtimeconfig.json",
+            "bar.dll.config",
+            "baz.exe.config",
+            "test.shasum",
+            "image.png",
+        ]
+        for path in paths:
+            matched = any(
+                fnmatch(path, pattern) for pattern in flag.NUGET_IGNORED_PATTERNS
+            )
+            self.assertTrue(matched, path)

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -427,7 +427,11 @@ class ScanPipePipelinesTest(TestCase):
             pipeline.flag_ignored_resources()
 
         mock_flag.assert_called_once()
-        patterns_args = ["*.ext", *flag.DEFAULT_IGNORED_PATTERNS]
+        patterns_args = [
+            "*.ext",
+            *flag.DEFAULT_IGNORED_PATTERNS,
+            *flag.NUGET_IGNORED_PATTERNS,
+        ]
         self.assertEqual(mock_flag.mock_calls[0].kwargs["patterns"], patterns_args)
         self.assertEqual(mock_flag.mock_calls[0].kwargs["codebaseresources"].count(), 0)
 


### PR DESCRIPTION
## Issues
Closes: #1791

Added ignore patterns for NuGet metadata and configuration files that are not useful for analysis in extracted .nupkg archives. Defined NUGET_IGNORED_PATTERNS and applied them in the pipeline when flagging ignored resources.
Also included unit test and update pipeline tests.
