### PR TITLE
Fix: XLSX Error Message Overwrites Last Data Column

### DIFF
--- a/scanpipe/pipes/output.py
+++ b/scanpipe/pipes/output.py
@@ -382,7 +382,7 @@ def add_xlsx_worksheet(workbook, worksheet_name, rows, fields):
     worksheet.write_row(row=0, col=0, data=header, cell_format=cell_format)
 
     errors_count = 0
-    errors_col_index = len(fields) - 1  # rows and cols are zero-indexed
+    errors_col_index = len(fields)  # xlsx_errors column comes after all data fields
 
     for row_index, record in enumerate(rows, start=1):
         row_errors = []

--- a/scanpipe/tests/pipes/test_output.py
+++ b/scanpipe/tests/pipes/test_output.py
@@ -810,6 +810,51 @@ class ScanPipeXLSXOutputPipesTest(TestCase):
             if r != x:
                 self.assertEqual(r[-50:], x)
 
+    def test_add_xlsx_worksheet_writes_xlsx_errors_after_all_data_columns(self):
+        """
+        With multiple data columns, truncation errors must go to the trailing
+        ``xlsx_errors`` column, not overwrite the last data field.
+        """
+        test_dir = Path(tempfile.mkdtemp(prefix="scancode-io-test"))
+        output_file = test_dir / "multi-field-long-cell.xlsx"
+        len_32760_string = "f" * 32760
+        len_10_string = "0123456789"
+        long_name = len_32760_string + len_10_string
+        path_value = "/expected/path/value"
+
+        rows = [{"name": long_name, "path": path_value}]
+        fields = ["name", "path"]
+
+        with xlsxwriter.Workbook(str(output_file)) as workbook:
+            output.add_xlsx_worksheet(
+                workbook=workbook,
+                worksheet_name="packages",
+                rows=rows,
+                fields=fields,
+            )
+
+        wb = openpyxl.load_workbook(output_file, read_only=True, data_only=True)
+        try:
+            ws = wb["packages"]
+
+            self.assertEqual(ws.cell(1, 1).value, "name")
+            self.assertEqual(ws.cell(1, 2).value, "path")
+            self.assertEqual(ws.cell(1, 3).value, "xlsx_errors")
+
+            name_cell = ws.cell(2, 1).value
+            path_cell = ws.cell(2, 2).value
+            errors_cell = ws.cell(2, 3).value
+        finally:
+            wb.close()
+
+        self.assertEqual(len(name_cell), 32767)
+        self.assertTrue(name_cell.startswith("f"))
+        self.assertEqual(path_value, path_cell)
+        self.assertIsNotNone(errors_cell)
+        self.assertIn("name", errors_cell)
+        self.assertIn("truncated", errors_cell.lower())
+        self.assertIn("32767", errors_cell)
+
     def test_add_xlsx_worksheet_does_not_munge_long_strings_of_over_1024_lines(self):
         # This test verifies that we do not truncate long text silently
 


### PR DESCRIPTION
## Issues

- Closes: #2088

## Changes

**What was fixed:**
When exporting project results to XLSX format, if any field value exceeded Excel's 32,767 character cell limit, the truncation warning was being written to the wrong column. Specifically, it was overwriting the last actual data column instead of landing in the dedicated `xlsx_errors` column. This caused silent data loss in the last column, while the actual error column remained blank. 

**Root Cause & Reasoning:**
In `scanpipe/pipes/output.py`, the index for the error column was incorrectly calculated as `len(fields) - 1`. Since columns are zero-indexed and the `xlsx_errors` column is appended *after* all data fields, the correct index is simply `len(fields)`. 

*(Note: The existing test suite did not catch this because it only used a single data field. With one field, `len(1) - 1` evaluates to `0`, which coincidentally matched the data column itself.)*

**What was updated:**
1. **Core Fix:** Updated `add_xlsx_worksheet` in `scanpipe/pipes/output.py` to correctly index the errors column (`errors_col_index = len(fields)`).
2. **New Tests:** Added a new test case in `scanpipe/tests/pipes/test_output.py` that utilizes multiple fields and a value exceeding the XLSX cell length limit. This explicitly verifies that:
   - The last data column retains its actual value.
   - The `xlsx_errors` column correctly contains the truncation warning.
3. **Verification:** Ran `python manage.py test scanpipe.tests.pipes.test_output.ScanPipeXLSXOutputPipesTest`. All 17 tests pass successfully.

*I used an AI assistant (Gemini) solely to help proofread and format this PR description. All code, debugging, and testing were done manually.*

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR