### PR TITLE
Update “Errors” section to “Messages” in ScanCode.io Web UI tutorial

### DIFF
--- a/docs/tutorial_web_ui_review_scan_results.rst
+++ b/docs/tutorial_web_ui_review_scan_results.rst
@@ -17,7 +17,7 @@ results using the ScanCode.io web interface.
 
 On the homepage, you can click on the project name in the summary table to
 access a detailed project output page. You can also click any of the numbers
-underneath the **Packages**, **Resources**, or **Errors** fields to be directed
+underneath the **Packages**, **Resources**, or **Messages** fields to be directed
 to the field's corresponding information. Further, clicking on the pipeline's
 execution status —**Success** in this case— expands some extra pipeline details,
 Resources status, and Run log.
@@ -68,11 +68,19 @@ resources by **Programming Language**, **Mime Type**, **Holder**, **Copyright**,
 
 .. image:: images/tutorial-web-ui-resources-filter.png
 
-Errors
-------
+Messages
+--------
 In addition to discovered packages and codebase resources, the ScanCode.io
-homepage shows the number of existing errors, which you can click for detailed
-description of each error.
+homepage shows the number of messages, which you can click to view detailed
+information.
+
+Messages can have different severity levels such as INFO, WARNING, and ERROR.
+
+.. note::
+
+   In previous versions of ScanCode.io, errors were displayed in a dedicated
+   “Errors” section. This has now been replaced by a more general “Messages”
+   system that includes INFO, WARNING, and ERROR levels.
 
 .. image:: images/tutorial-web-ui-errors-list.png
 


### PR DESCRIPTION
## Description

Updates the ScanCode.io tutorial documentation to match the current Web UI. The "Errors" section is now referred to as "Messages", and the tutorial now explains that messages can have severities: INFO, WARNING, or ERROR. Screenshots have been updated to reflect the current layout.

## Issues

- Closes: #2050

## Changes

- Updated docs/tutorial_web_ui_review_scan_results.rst
- Replaced all references to "Errors" with "Messages"
- Added explanation about message severities
- Added a note that older versions used "Errors"

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [ ] I have added unit tests covering the new code (not applicable since this is documentation)
- [x] I have reviewed and understood every line of this PR
