### PR TITLE
Fix: handle empty response in bulk_search_by_purl to prevent runtime errors

### DIFF
--- a/scanpipe/pipes/vulnerablecode.py
+++ b/scanpipe/pipes/vulnerablecode.py
@@ -223,6 +223,8 @@ def fetch_vulnerabilities(
 
     for purls_batch in chunked(get_purls(packages), chunk_size):
         response_data = bulk_search_by_purl(purls_batch)
+        if not response_data:
+            continue
         for vulnerability_data in response_data:
             vulnerabilities_by_purl[vulnerability_data["purl"]] = vulnerability_data
 


### PR DESCRIPTION
## Issues
- Closes: N/A

## Changes
The `fetch_vulnerabilities` function isn't able to handle cases where `bulk_search_by_purl` may return None or an empty response.
Currently, the code assumes that the response is always iterable, which can lead to runtime errors if the API returns an empty or error response. Therefore I introduced a simple guard condition to skip function when no data is returned.

## Checklist
- [Y ] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [ ] I have linked an existing issue above
- [ ] I have added unit tests covering the new code
- [Y ] I have reviewed and understood every line of this PR
