### PR TITLE
Fix 2116: Fix duplicate input filename by adding unique naming

### DIFF
--- a/scanpipe/pipes/input.py
+++ b/scanpipe/pipes/input.py
@@ -66,6 +66,12 @@ def copy_inputs(input_locations, dest_path):
 def move_input(input_location, dest_path):
     """Move the provided ``input_location`` to the ``dest_path``."""
     destination = dest_path / Path(input_location).name
+    i = 2
+    while destination.exists():
+        input_path = Path(input_location)
+        destination = dest_path / f"{input_path.stem}_{i}{input_path.suffix}"
+        i += 1
+
     return shutil.move(input_location, destination)
 
 

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -22,6 +22,7 @@
 
 import io
 import json
+import os
 import shutil
 import sys
 import tempfile
@@ -410,6 +411,27 @@ class ScanPipeModelsTest(TestCase):
         self.project1.move_input_from(input_location)
         self.assertEqual([input_filename], self.project1.input_files)
         self.assertFalse(Path(input_location).exists())
+
+    def test_move_input_handles_duplicate_filenames(self):
+        # Create first file
+        fd1, path1 = tempfile.mkstemp(suffix=".txt")
+        os.close(fd1)
+        Path(path1).write_text("one")
+
+        # Create second file with same name in same directory
+        temp_dir = Path(path1).parent
+        path2 = temp_dir / Path(path1).name
+        Path(path2).write_text("two")
+
+        # Move both into project input
+        dest1 = self.project1.move_input_from(path1)
+        dest2 = self.project1.move_input_from(path2)
+
+        # Ensure both files exist
+        self.assertTrue(Path(dest1).exists())
+        self.assertTrue(Path(dest2).exists())
+        # Ensure filenames are different
+        self.assertNotEqual(Path(dest1).name, Path(dest2).name)
 
     def test_scanpipe_project_model_get_inputs_with_source(self):
         self.assertEqual([], self.project1.get_inputs_with_source())


### PR DESCRIPTION
## Issues

- Closes: #2116

## Changes

Fixed issue where multiple input files with the same filename were being overwritten. if a file with the same name already exists in the input directory, a numeric suffix (like 2, 3...) is added to create a unique filename instead of overwriting the existing file.Added a unit test to verify that duplicate filenames are handled correctly.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR

<img width="1789" height="737" alt="image" src="https://github.com/user-attachments/assets/c9405b4a-42ee-403c-a512-1a5c7923aeaa" />
