### PR TITLE
fix: relax validation for non-HTTP URLs

### DIFF
--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -2012,9 +2012,10 @@ class InputSource(UUIDPKModel, ProjectRelatedModel):
         if not self.download_url:
             raise ValueError("No `download_url` value to be fetched.")
 
-        is_safe_and_available = fetch.check_url(self.download_url)
-        if not is_safe_and_available:
-            raise ValidationError(f"Could not fetch: {self.download_url}")
+        if self.download_url.startswith("http"):
+            is_safe_and_available = fetch.check_url(self.download_url)
+            if not is_safe_and_available:
+                raise ValidationError(f"Could not fetch: {self.download_url}")
 
         downloaded = fetch.fetch_url(url=self.download_url)
         destination = self.project.move_input_from(downloaded.path)

--- a/scanpipe/pipes/fetch.py
+++ b/scanpipe/pipes/fetch.py
@@ -457,5 +457,5 @@ def check_url(url):
 
 def check_urls_availability(urls):
     """Check the safety and accessibility of a list of URLs."""
-    errors = [url for url in urls if not check_url(url)]
+    errors = [url for url in urls if not check_url(url) if url.startswith("http")]
     return errors

--- a/scanpipe/tests/pipes/test_fetch.py
+++ b/scanpipe/tests/pipes/test_fetch.py
@@ -334,9 +334,13 @@ class ScanPipeFetchPipesTest(TestCase):
     def test_scanpipe_pipes_fetch_check_urls_availability(
         self, mock_head, mock_gethostbyname
     ):
-        urls = [
+        http_urls = [
             "https://example.com/file.zip",
             "https://example.com/archive.tar.gz",
+        ]
+        urls = http_urls + [
+            "docker://image",
+            "pkg:npm/name@version",
         ]
 
         # All URLs safe and accessible
@@ -346,4 +350,4 @@ class ScanPipeFetchPipesTest(TestCase):
 
         # All URLs fail
         mock_head.side_effect = requests.exceptions.RequestException
-        self.assertEqual(urls, fetch.check_urls_availability(urls))
+        self.assertEqual(http_urls, fetch.check_urls_availability(urls))

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -2888,6 +2888,7 @@ class ScanPipeModelsTest(TestCase):
             self.assertEqual(check.reason, expected["reason"])
             self.assertEqual(check.details, expected["details"] or [])
 
+    @override_settings(TIME_ZONE="UTC")
     def test_scanpipe_parse_score_date(self):
         """Test parse_score_date with valid, invalid, and custom date formats."""
         # Valid date formats


### PR DESCRIPTION
## Issues

- Closes: #2146

