### PR TITLE
fix: replace the hardcoded /var/www/html by named volume

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,10 +18,14 @@ services:
       - .env
     environment:
       <<: *dev-env
-    command: ./manage.py runserver --skip-checks 0.0.0.0:8001
+    # Skip migrate when the DB schema is already up to date (faster reload)
+    command: sh -c "
+      ./manage.py migrate --check || ./manage.py migrate;
+      ./manage.py runserver --skip-checks 0.0.0.0:8001"
     volumes:
       - ./scanpipe:/opt/scancodeio/scanpipe
     ports:
+      # Port 8001 to avoid conflict when running side-by-side with dejacode on 8000
       - "8001:8001"
 
   # Volume mount keeps code in sync. Restart manually with: make restart-worker

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,10 +36,12 @@ services:
       - .env
     environment:
       <<: *dev-env
-    command: ./manage.py rqworker --worker-class scancodeio.worker.ScanCodeIOWorker
-                                  --queue-class scancodeio.worker.ScanCodeIOQueue
-                                  --verbosity 1
+    command: wait-for-it --strict --timeout=180 web:8001 -- sh -c "
+      ./manage.py rqworker --worker-class scancodeio.worker.ScanCodeIOWorker
+      --queue-class scancodeio.worker.ScanCodeIOQueue
+      --verbosity 1"
     volumes:
+      - ./scancodeio:/opt/scancodeio/scancodeio
       - ./scanpipe:/opt/scancodeio/scanpipe
 
   # Disable nginx in dev mode, the runserver serves requests directly.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,7 @@ services:
       ./manage.py migrate --check || ./manage.py migrate;
       ./manage.py runserver --skip-checks 0.0.0.0:8001"
     volumes:
+      - ./scancodeio:/opt/scancodeio/scancodeio
       - ./scanpipe:/opt/scancodeio/scanpipe
     ports:
       # Port 8001 to avoid conflict when running side-by-side with dejacode on 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
         ./manage.py migrate &&
         ./manage.py collectstatic --no-input --verbosity 0 --clear &&
         gunicorn scancodeio.wsgi:application --bind :8000 --timeout 600 \
-          --workers 8 ${GUNICORN_RELOAD_FLAG:-}"
+          --workers 8 --worker-tmp-dir /dev/shm ${GUNICORN_RELOAD_FLAG:-}"
     env_file:
       - docker.env
     expose:
@@ -91,6 +91,8 @@ services:
       db:
         condition: service_healthy
       redis:
+        condition: service_started
+      clamav:
         condition: service_started
 
   worker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,8 +118,8 @@ services:
       - "${NGINX_PUBLISHED_HTTPS_PORT:-443}:443"
     volumes:
       - ./etc/nginx/conf.d/:/etc/nginx/conf.d/
-      - /var/www/html:/var/www/html
       - static:/var/scancodeio/static/
+      - webroot:/var/www/html/
     depends_on:
       - web
     restart: always
@@ -137,3 +137,4 @@ volumes:
   clamav_data:
   static:
   workspace:
+  webroot:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,8 +92,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      clamav:
-        condition: service_started
 
   worker:
     build: .


### PR DESCRIPTION
## Issues

- Issue: #2157

## Changes

Replace the hardcoded ``/var/www/html`` by a ``webroot`` named volume in ``docker-compose.yml``.

In the Docker compose ``nginx`` service, the hardcoded ``/var/www/html`` was declared
as a volume which would cause issues when the ``/var/`` was not available on the
local machine.

The Docker volume directory ``/var/lib/docker/volumes/scancodeio_webroot/_data`` can
now be used in place of ``/var/www/html`` as the ``certbot --webroot-path`` for
HTTP certificate management.

See also https://github.com/aboutcode-org/dejacode/issues/157 and https://github.com/aboutcode-org/dejacode/commit/74976c1334ded516a7edaeda8b35a5d8db02548c for the fix on the DejaCode side.
