### PR TITLE
chore: bump minecode-pipelines version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ android_analysis = [
   "android_inspector==0.2.0"
 ]
 mining = [
-  "minecode_pipelines==0.1.1"
+  "minecode_pipelines==1.0.0"
 ]
 
 [project.urls]

--- a/scanpipe/pipes/federatedcode.py
+++ b/scanpipe/pipes/federatedcode.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 import textwrap
 from pathlib import Path
+from time import sleep
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 
@@ -194,7 +195,7 @@ def get_github_org(url):
     return org_name
 
 
-def create_repository(repo_name, clone_path, logger, shallow_clone=True):
+def create_repository(repo_name, clone_path, logger, shallow_clone=True, timeout=3):
     """
     Create and initialize remote FederatedCode `repo_name` repository,
     perform local checkout, and return it.
@@ -222,6 +223,10 @@ def create_repository(repo_name, clone_path, logger, shallow_clone=True):
         timeout=5,
     )
     response.raise_for_status()
+
+    # sleep to allow github time to create the repo before we clone it
+    sleep(timeout)
+
     return clone_repository(
         repo_url=repo_url,
         clone_path=clone_path,


### PR DESCRIPTION
This PR bumps the minecode-pipelines version to 1.0.0 and modifies `scanpipe.pipes.federatedcode.create_repository` to have a timeout before cloning a newly-created repo. 

v1.0.0 of minecode-pipelines expands the cargo, maven, npm, and pypi pipelines to also collect package data for specific package versions.