### PR TITLE
chore: update minecode-pipelines version to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ android_analysis = [
   "android_inspector==0.2.0"
 ]
 mining = [
-  "minecode_pipelines==1.0.0"
+  "minecode_pipelines==1.0.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR updates `minecode-pipelines` to 1.0.1. This is to fix an issue where `api_package_version_response` data clusters were not being properly collected.