### PR TITLE
Install Java and jadx in Dockerfile #1812

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -40,39 +40,56 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract tags and labels that will be applied to the specified image.
-      # The `id` "meta" allows the output of this step to be referenced in a subsequent
-      # step.
-      # The `images` value provides the base name for the tags and labels.
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for base image
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build the image based on your repository's `Dockerfile`.
-      # If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of
-      # files located in the specified path.
-      # It uses the `tags` and `labels` parameters to tag and label the image with
-      # the output from the "meta" step.
-      - name: Build and push Docker image
+      - name: Extract metadata (tags, labels) for full image
+        id: meta-full
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-full
+
+      - name: Build and push base Docker image
         id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
+          target: core
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # This step generates an artifact attestation for the image, which is an
-      # unforgeable statement about where and how it was built.
-      # It increases supply chain security for people who consume the image.
-      - name: Generate artifact attestation
+      - name: Build and push full Docker image
+        id: push-full
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        with:
+          context: .
+          target: full
+          push: true
+          tags: ${{ steps.meta-full.outputs.tags }}
+          labels: ${{ steps.meta-full.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation for base image
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  #  v4.1.0
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for full image
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  #  v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push-full.outputs.digest }}
           push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@
 # ScanCode.io is a free software code scanning tool from nexB Inc. and others.
 # Visit https://github.com/aboutcode-org/scancode.io for support and download.
 
-# ============================================
+# ===================================================================
 # Stage 1: Build stage
-# ============================================
+# ===================================================================
 
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
 
@@ -45,18 +45,27 @@ WORKDIR $APP_DIR
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --extra android_analysis --frozen --no-install-project
+    uv sync --frozen --no-install-project
 
 # Only re-runs when local code changes
 COPY . $APP_DIR
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --extra android_analysis --frozen
+    uv sync --frozen
 
-# ============================================
-# Stage 2: Production stage (base)
-# ============================================
+# ===================================================================
+# Stage 1.5: Build stage for full image
+# ===================================================================
 
-FROM python:3.13-slim-bookworm AS base
+FROM builder AS builder-full
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --extra android_analysis
+
+# ===================================================================
+# Stage 2: Production stage (core)
+# ===================================================================
+
+FROM python:3.13-slim-bookworm AS core
 
 LABEL org.opencontainers.image.source="https://github.com/aboutcode-org/scancode.io"
 LABEL org.opencontainers.image.description="ScanCode.io"
@@ -122,11 +131,13 @@ USER $APP_USER
 # Create static/ and workspace/ directories
 RUN mkdir -p /var/$APP_NAME/static/ /var/$APP_NAME/workspace/
 
-# ============================================
-# Stage 3: Full image (with VM inspection)
-# ============================================
+# ===================================================================
+# Stage 3: Full image (with VM inspection and Android inspector)
+# ===================================================================
 
-FROM base AS full
+FROM core AS full
+
+COPY --from=builder-full --chown=$APP_USER:$APP_USER $APP_DIR $APP_DIR
 
 USER root
 RUN apt-get update \
@@ -134,14 +145,13 @@ RUN apt-get update \
        libguestfs-tools \
        linux-image-amd64 \
        openjdk-17-jre-headless \
-       unzip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Download jadx-1.5.0.zip and extract contents to /usr/bin/ and /usr/lib/
-ADD https://github.com/skylot/jadx/releases/download/v1.5.0/jadx-1.5.0.zip /tmp/jadx-1.5.0.zip
-RUN unzip -d /usr/ /tmp/jadx-1.5.0.zip && chmod +x /usr/bin/jadx && rm /tmp/jadx-1.5.0.zip
-RUN chmod +x /usr/bin/jadx
-RUN apt-get purge -y unzip
+RUN python3 -c "import urllib.request, zipfile, io; \
+    zipfile.ZipFile(io.BytesIO(urllib.request.urlopen( \
+    'https://github.com/skylot/jadx/releases/download/v1.5.0/jadx-1.5.0.zip' \
+    ).read())).extractall('/usr/')" \
+ && chmod +x /usr/bin/jadx
 
 USER $APP_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,12 @@ WORKDIR $APP_DIR
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project
+    uv sync --extra android_analysis --frozen --no-install-project
 
 # Only re-runs when local code changes
 COPY . $APP_DIR
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen
+    uv sync --extra android_analysis --frozen
 
 # ============================================
 # Stage 2: Production stage (base)
@@ -133,6 +133,15 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
        libguestfs-tools \
        linux-image-amd64 \
+       openjdk-17-jre-headless \
+       unzip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Download jadx-1.5.0.zip and extract contents to /usr/bin/ and /usr/lib/
+ADD https://github.com/skylot/jadx/releases/download/v1.5.0/jadx-1.5.0.zip /tmp/jadx-1.5.0.zip
+RUN unzip -d /usr/ /tmp/jadx-1.5.0.zip && chmod +x /usr/bin/jadx && rm /tmp/jadx-1.5.0.zip
+RUN chmod +x /usr/bin/jadx
+RUN apt-get purge -y unzip
+
 USER $APP_USER

--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,16 @@ restart-worker:
 	${COMPOSE} restart worker
 
 build:
-	# Build the dev Docker images
+	# Build the dev Docker images (core, hot reload)
 	${COMPOSE} build
 
+build-core:
+	# Build the production core Docker image
+	docker build --target core -t $(IMAGE_NAME) .
+
 build-full:
-	# Build the full production Docker image
-	docker build --target full -t $(IMAGE_NAME) .
+	# Build the production full Docker image
+	docker build --target full -t $(IMAGE_NAME):full .
 
 regen-fixtures:
 	@echo "-> Regenerate test fixtures from the running Docker stack"
@@ -204,4 +208,4 @@ offline-package: docker-images
 	@mkdir -p dist/
 	@tar -cf dist/scancodeio-offline-package-`git describe --tags`.tar build/
 
-.PHONY: virtualenv conf dev envfile install doc8 check valid check-deploy clean migrate makemigrations restart-worker postgresdb sqlitedb backupdb run test fasttest regen-fixtures fix docs build bash shell docker-images offline-package
+.PHONY: virtualenv conf dev envfile install doc8 check valid check-deploy clean migrate makemigrations restart-worker postgresdb sqlitedb backupdb run test fasttest regen-fixtures fix docs build build-core build-full bash shell docker-images offline-package

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ x-dev-env: &dev-env
 
 x-dev-build: &dev-build
   context: .
-  target: base
+  target: core
 
 services:
   web:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,43 +51,14 @@ create an **environment file**, and **build the Docker image**::
     make envfile
     docker compose build
 
-.. warning::
-    As the ``docker-compose`` v1 command is officially deprecated by Docker, you will
-    only find references to the ``docker compose`` v2 command in this documentation.
-
 .. note::
-    If you intend to run an Android deploy to develop project, ``Java``, ``jadx
-    v1.5.0`` and ``android-inspector`` must be installed in the Docker image by
-    adding the following lines to the ``Dockerfile`` and rebuilding the Docker
-    image:
+    To use the Android analysis pipeline, use the ``full`` Docker image which
+    includes OpenJDK, jadx, and android-inspector. The production
+    ``docker-compose.yml`` builds the ``full`` image by default.
 
-    Add at line 65 after `apt-get` command::
+    For local development, build the full image explicitly::
 
-        # Install Java and utilities to install jadx
-        RUN apt-get update \
-        && apt-get install -y --no-install-recommends \
-            openjdk-17-jre-headless \
-            unzip \
-            wget
-
-        # Download and extract jadx
-        RUN wget https://github.com/skylot/jadx/releases/download/v1.5.0/jadx-1.5.0.zip \
-        && unzip -d /usr jadx-1.5.0.zip
-
-        # Remove jadx archive and installed utilities
-        RUN apt-get remove -y unzip wget \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-        && rm jadx-1.5.0.zip
-
-    Add at end of file::
-
-        # Install android-inspector
-        RUN pip install --no-cache-dir android-inspector
-
-    Rebuild the image::
-
-        docker compose build
+        make build-full
 
 Run the App
 ^^^^^^^^^^^

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "aboutcode-federated"
-version = "0.1.0"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packageurl-python" },
@@ -21,9 +21,9 @@ dependencies = [
     { name = "saneyaml" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/d8/e46773bbb8df82b09863fe8204504d2f0094f2cec36449b7ce1a8c76e4e3/aboutcode_federated-0.1.0.tar.gz", hash = "sha256:bd58fbd77d4f8c24536822c0d969a0af7f44da59a7fa3cf3b9baa3943e4c1392", size = 20705, upload-time = "2025-11-25T19:07:27.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/61/c803f75b5f7b1d3c43fb52085527980f012dd46ee2fd52c6f18f06b2dae6/aboutcode_federated-1.0.4.tar.gz", hash = "sha256:3999244301fabd8a4fcc69c5015251b183983a090a2bfdbfe114bf97f2f05099", size = 34532, upload-time = "2026-06-03T18:26:12.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/9b/04924ad8dd97c375ba84a00fbf17822e61380a3518a15c8f436f4ca034d6/aboutcode_federated-0.1.0-py3-none-any.whl", hash = "sha256:25068ae0cefbc2cf80fab35bf97d4e9b89d9b297f2dc016cd98f013f9ada9a4c", size = 23141, upload-time = "2025-11-25T19:07:26.139Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b2/72af1562cdceb780dacbd4adb5891b19f89b3a7dd4da4d7ce2df7a76241b/aboutcode_federated-1.0.4-py3-none-any.whl", hash = "sha256:e5fe1a709d620fd53864a7ec5dab1311cd50a392e627dfa9354d236c1c2b2387", size = 21986, upload-time = "2026-06-03T18:26:11.184Z" },
 ]
 
 [[package]]
@@ -1724,7 +1724,7 @@ wheels = [
 
 [[package]]
 name = "minecode-pipelines"
-version = "0.1.1"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aboutcode-federated" },
@@ -1736,9 +1736,9 @@ dependencies = [
     { name = "packageurl-python" },
     { name = "scancodeio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/0e/9d3374c854237f94c0cdee3684354feaf2a498fbaac7adf67a5da2bafb71/minecode_pipelines-0.1.1.tar.gz", hash = "sha256:e53dcefd312fa08276a9932ba99127ff29b4f070a9800f8e5fe157b7057cf96b", size = 42336, upload-time = "2025-12-12T17:39:23.619Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/04/fef63efe49dda56679387314fe3d8a296b9e66658c488ad82a47598857b8/minecode_pipelines-1.0.1.tar.gz", hash = "sha256:84e71ad930db6deda29b3c82b0695dea5e5c416aaba0b9db048bbb0b880c9424", size = 44198, upload-time = "2026-05-19T22:27:55.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/0c/068543049cc4c9c8fbae66bb13525378eede389d2d5f0fc81e74457f3476/minecode_pipelines-0.1.1-py3-none-any.whl", hash = "sha256:0572ef016b0080246e074a90a475bfbb48df8d39e19328025ebe48d9e874bb93", size = 73161, upload-time = "2025-12-12T17:39:22.25Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/ffd25dd972a7aa66f49f8b7336b1026a1755cf2056f603abae220ee4886f/minecode_pipelines-1.0.1-py3-none-any.whl", hash = "sha256:2485859eaba9a36e6508c51844631857650f4fdb1cfc45f53a6d1c46376e62dd", size = 75074, upload-time = "2026-05-19T22:27:54.296Z" },
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ requires-dist = [
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "markdown-it-py", specifier = "==4.0.0" },
     { name = "matchcode-toolkit", specifier = "==7.2.2" },
-    { name = "minecode-pipelines", marker = "extra == 'mining'", specifier = "==0.1.1" },
+    { name = "minecode-pipelines", marker = "extra == 'mining'", specifier = "==1.0.1" },
     { name = "openpyxl", specifier = "==3.1.5" },
     { name = "packageurl-python", specifier = "==0.17.6" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.3" },
@@ -3437,6 +3437,12 @@ version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/85/a61c782afbb706a47d990eaee6977e7c2bd013771c5bf5c81c617684f286/tree_sitter_c_sharp-0.23.1.tar.gz", hash = "sha256:322e2cfd3a547a840375276b2aea3335fa6458aeac082f6c60fec3f745c967eb", size = 1317728, upload-time = "2024-11-11T05:25:32.535Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/18/0571a3a34c0feda60a9c37cf6dd5edfdbc24f8fcb1e48b6b6eb0f324ad2a/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:035d259e64c41d02cc45afc3b8b46388b232e7d16d84734d851cca7334761da5", size = 358331, upload-time = "2026-04-14T15:11:16.418Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/0f7e1f50f6365338eb700f01710da0adc49a49fa9a8443e5a90ea4f29491/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa472cb9de7e14fee9408e144f29f68384cd8e9c677dff0002da19f361a59bdf", size = 359444, upload-time = "2026-04-14T15:11:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/98/60/129bd56d5ef22b4ae254940a09b6d3ed873093218868a3f9635d571d514e/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1a0ea86eccff74e85ab4a2cf77c813fad7c84162962ce242dff0c51601028832", size = 358143, upload-time = "2026-04-14T15:11:18.755Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/cd/e12cdca47e0c56151cb4b156d48091b7bc1d968e072c1656cf6b73fe7218/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8ab26dc998bbd4b4287b129f67c10ca715deb402ed77d0645674490ea509097e", size = 357524, upload-time = "2026-04-14T15:11:19.717Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2c/f742d60f818cba83760f4975c7158d1c96c36b5807e95a843db7fb8c64b7/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:d4486653feaff3314ef45534dcb6f9ea8ab3aa160896287c6473788f88eb38be", size = 338755, upload-time = "2026-04-14T15:11:20.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e4/8a8642b9bba86248ac2facc81ffb187c06c6768efa56c79d61fab70d736b/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:e7a14b76ec23cc8386cf662d5ea602d81331376c93ca6299a97b174047790345", size = 337261, upload-time = "2026-04-14T15:11:22.111Z" },
     { url = "https://files.pythonhosted.org/packages/0f/21/13df29f8fcb9ba9f209b7b413a4764b673dfd58989a0dd67e9c7e19e9c2e/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:986e93d845a438ec3c4416401aa98e6a6f6631d644bbbc2e43fcb915c51d255d", size = 415999, upload-time = "2024-11-11T05:25:22.359Z" },
     { url = "https://files.pythonhosted.org/packages/ca/72/fc6846795bcdae2f8aa94cc8b1d1af33d634e08be63e294ff0d6794b1efc/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8024e466b2f5611c6dc90321f232d8584893c7fb88b75e4a831992f877616d2", size = 402830, upload-time = "2024-11-11T05:25:24.198Z" },
     { url = "https://files.pythonhosted.org/packages/fe/3a/b6028c5890ce6653807d5fa88c72232c027c6ceb480dbeb3b186d60e5971/tree_sitter_c_sharp-0.23.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7f9bf876866835492281d336b9e1f9626ab668737f74e914c31d285261507da7", size = 397880, upload-time = "2024-11-11T05:25:25.937Z" },


### PR DESCRIPTION
This PR addresses #1812 by modifying the Dockerfile to install Java, jadx, and android-inspector, allowing us to use the android d2d pipeline. uv.lock has been updated to the new versions of aboutcode.federated, minecode-pipelines.