### PR TITLE
Security: Sensitive Token Data Exposure in Migration Logging

### DIFF
--- a/scanpipe/migrations/0079_apitoken_data.py
+++ b/scanpipe/migrations/0079_apitoken_data.py
@@ -31,9 +31,7 @@ def migrate_api_tokens(apps, schema_editor):
         )
         for user_id, key, created in rows
     ]
-    migrated_tokens = APIToken.objects.bulk_create(tokens_to_create, ignore_conflicts=True)
-    if migrated_tokens:
-        print(f" -> {len(migrated_tokens)} tokens migrated.")
+    APIToken.objects.bulk_create(tokens_to_create, ignore_conflicts=True)
 
 
 def reverse_migrate_api_tokens(apps, schema_editor):


### PR DESCRIPTION
## Summary

Security: Sensitive Token Data Exposure in Migration Logging

## Problem

**Severity**: `Low` | **File**: `scanpipe/migrations/0079_apitoken_data.py:L35`

Migration 0079_apitoken_data.py prints the count of migrated tokens with `print(f" -> {len(migrated_tokens)} tokens migrated.")`. While this only logs the count, the migration handles sensitive API token data. More importantly, the migration reads plaintext tokens from the `authtoken_token` table and hashes them with `make_password(key)`. The use of `print()` in migrations can leak information to logs, and the migration's handling of plaintext tokens should ensure no token values are ever logged.

## Solution

Remove the print statement or replace it with proper logging at an appropriate level. Ensure that no token values, prefixes, or hashes are ever logged. Consider using Django's migration logging framework instead of print().

## Changes

- `scanpipe/migrations/0079_apitoken_data.py` (modified)