### PR TITLE
Fix get_data_from_manifests returning wrong type on early exit

### DIFF
--- a/scanpipe/pipes/resolve.py
+++ b/scanpipe/pipes/resolve.py
@@ -95,7 +95,7 @@ def get_data_from_manifests(project, package_registry, manifest_resources, model
             description="No resources containing package data found in codebase.",
             model=model,
         )
-        return []
+        return [], []
 
     for resource in manifest_resources:
         packages = resolve_manifest_resources(resource, package_registry)

--- a/scanpipe/tests/pipes/test_resolve.py
+++ b/scanpipe/tests/pipes/test_resolve.py
@@ -391,3 +391,32 @@ class ScanPipeResolvePipesTest(TestCase):
         ]
         headers = resolve.get_manifest_headers(resource)
         self.assertEqual(expected, list(headers.keys()))
+    def test_get_data_from_manifests_returns_tuple_when_no_resources(self):
+    """
+    Regression test: get_data_from_manifests must always return a tuple
+    of (packages, dependencies), even when manifest_resources is empty.
+
+    Bug: when manifest_resources.exists() is False, the function returned
+    a bare [] instead of ([], []), causing ValueError when callers tried
+    to unpack: packages, dependencies = get_data_from_manifests(...)
+    """
+    project1 = Project.objects.create(name="TestEmptyManifest")
+
+    # Use an empty queryset — no manifest resources exist
+    empty_resources = project1.codebaseresources.none()
+
+    result = resolve.get_data_from_manifests(
+        project=project1,
+        package_registry=resolve.sbom_registry,
+        manifest_resources=empty_resources,
+        model="test",
+    )
+
+    # Must be unpackable as a tuple — this would raise ValueError before the fix
+    packages, dependencies = result
+
+    self.assertEqual(packages, [])
+    self.assertEqual(dependencies, [])
+
+    # A warning should have been added to the project
+    self.assertEqual(1, project1.projectmessages.count())

--- a/scanpipe/tests/pipes/test_resolve.py
+++ b/scanpipe/tests/pipes/test_resolve.py
@@ -391,32 +391,19 @@ class ScanPipeResolvePipesTest(TestCase):
         ]
         headers = resolve.get_manifest_headers(resource)
         self.assertEqual(expected, list(headers.keys()))
+
     def test_get_data_from_manifests_returns_tuple_when_no_resources(self):
-    """
-    Regression test: get_data_from_manifests must always return a tuple
-    of (packages, dependencies), even when manifest_resources is empty.
-
-    Bug: when manifest_resources.exists() is False, the function returned
-    a bare [] instead of ([], []), causing ValueError when callers tried
-    to unpack: packages, dependencies = get_data_from_manifests(...)
-    """
-    project1 = Project.objects.create(name="TestEmptyManifest")
-
-    # Use an empty queryset — no manifest resources exist
-    empty_resources = project1.codebaseresources.none()
-
-    result = resolve.get_data_from_manifests(
-        project=project1,
-        package_registry=resolve.sbom_registry,
-        manifest_resources=empty_resources,
-        model="test",
-    )
-
-    # Must be unpackable as a tuple — this would raise ValueError before the fix
-    packages, dependencies = result
-
-    self.assertEqual(packages, [])
-    self.assertEqual(dependencies, [])
-
-    # A warning should have been added to the project
-    self.assertEqual(1, project1.projectmessages.count())
+        project1 = Project.objects.create(name="TestEmptyManifest")
+        empty_resources = project1.codebaseresources.none()
+    
+        result = resolve.get_data_from_manifests(
+            project=project1,
+            package_registry=resolve.sbom_registry,
+            manifest_resources=empty_resources,
+            model="test",
+        )
+    
+        packages, dependencies = result
+        self.assertEqual(packages, [])
+        self.assertEqual(dependencies, [])
+        self.assertEqual(1, project1.projectmessages.count())

--- a/scanpipe/tests/pipes/test_resolve.py
+++ b/scanpipe/tests/pipes/test_resolve.py
@@ -395,14 +395,12 @@ class ScanPipeResolvePipesTest(TestCase):
     def test_get_data_from_manifests_returns_tuple_when_no_resources(self):
         project1 = Project.objects.create(name="TestEmptyManifest")
         empty_resources = project1.codebaseresources.none()
-    
         result = resolve.get_data_from_manifests(
             project=project1,
             package_registry=resolve.sbom_registry,
             manifest_resources=empty_resources,
             model="test",
         )
-    
         packages, dependencies = result
         self.assertEqual(packages, [])
         self.assertEqual(dependencies, [])


### PR DESCRIPTION
## What
Fix `get_data_from_manifests` returning a bare `[]` instead of `([], [])` when no manifest resources exist.

## Why
All callers unpack the return value as a two-tuple:

    packages, dependencies = resolve.get_data_from_manifests(...)

This is done in two pipelines:
- `scanpipe/pipelines/load_sbom.py` line 59
- `scanpipe/pipelines/resolve_dependencies.py` line 87

When `manifest_resources.exists()` is False, the function hit:

    return []   ← wrong type

This causes a `ValueError: not enough values to unpack` crash, crashing the entire LoadSBOM and ResolveDependencies pipelines
whenever a project has no manifest resources.

## Fix
One character change in `scanpipe/pipes/resolve.py`:

- return []
+ return [], []

Added a regression test to verify the function always returns a two-tuple even when manifest_resources is empty.