### PR TITLE
feat: add pipeline availability check with disabled state in UI

### DIFF
--- a/scancodeio/static/main.css
+++ b/scancodeio/static/main.css
@@ -119,6 +119,9 @@
   cursor: help;
   border-bottom: dotted 1px;
 }
+.modal.is-medium-size .modal-card {
+  width: 800px;
+}
 .modal.is-desktop-size .modal-card {
   width: 960px;
 }

--- a/scanpipe/pipelines/__init__.py
+++ b/scanpipe/pipelines/__init__.py
@@ -191,9 +191,23 @@ class ProjectPipeline(CommonStepsMixin, BasePipeline):
             return (cls.download_missing_inputs,)
 
     @classmethod
+    def get_availability(cls):
+        """
+        Return None if this pipeline is available, or a reason string if not.
+
+        Override in subclasses to implement dynamic availability checks,
+        such as verifying that a required external service is configured.
+        """
+        return None
+
+    @classmethod
     def get_info(cls, as_html=False):
         """Add the option to render the values as HTML."""
         info = super().get_info()
+
+        unavailable_reason = cls.get_availability()
+        info["is_available"] = unavailable_reason is None
+        info["unavailable_reason"] = unavailable_reason or ""
 
         if as_html:
             info["summary"] = convert_markdown_to_html(info["summary"])

--- a/scanpipe/pipelines/enrich_with_purldb.py
+++ b/scanpipe/pipelines/enrich_with_purldb.py
@@ -38,6 +38,11 @@ class EnrichWithPurlDB(Pipeline):
             cls.enrich_discovered_packages_with_purldb,
         )
 
+    @classmethod
+    def get_availability(cls):
+        if not purldb.is_configured():
+            return "PurlDB is not configured."
+
     def enrich_discovered_packages_with_purldb(self):
         """Lookup discovered packages in PurlDB."""
         purldb.enrich_discovered_packages(self.project, logger=self.log)

--- a/scanpipe/pipelines/find_vulnerabilities.py
+++ b/scanpipe/pipelines/find_vulnerabilities.py
@@ -43,6 +43,11 @@ class FindVulnerabilities(Pipeline):
             cls.lookup_dependencies_vulnerabilities,
         )
 
+    @classmethod
+    def get_availability(cls):
+        if not vulnerablecode.is_configured():
+            return "VulnerableCode is not configured."
+
     def check_vulnerablecode_service_availability(self):
         """Check if the VulnerableCode service if configured and available."""
         if not vulnerablecode.is_configured():

--- a/scanpipe/pipelines/match_to_matchcode.py
+++ b/scanpipe/pipelines/match_to_matchcode.py
@@ -57,6 +57,11 @@ class MatchToMatchCode(Pipeline):
             cls.create_packages_from_match_results,
         )
 
+    @classmethod
+    def get_availability(cls):
+        if not matchcode.is_configured():
+            return "MatchCode.io is not configured."
+
     def check_matchcode_service_availability(self):
         """Check if the MatchCode.io service if configured and available."""
         if not matchcode.is_configured():

--- a/scanpipe/pipelines/populate_purldb.py
+++ b/scanpipe/pipelines/populate_purldb.py
@@ -33,9 +33,15 @@ class PopulatePurlDB(Pipeline):
     @classmethod
     def steps(cls):
         return (
+            purldb.check_service_availability,
             cls.populate_purldb_with_discovered_packages,
             cls.populate_purldb_with_discovered_dependencies,
         )
+
+    @classmethod
+    def get_availability(cls):
+        if not purldb.is_configured():
+            return "PurlDB is not configured."
 
     def populate_purldb_with_discovered_packages(self):
         """Add DiscoveredPackage to PurlDB."""

--- a/scanpipe/pipelines/publish_to_federatedcode.py
+++ b/scanpipe/pipelines/publish_to_federatedcode.py
@@ -51,6 +51,11 @@ class PublishToFederatedCode(Pipeline):
             cls.delete_working_dir,
         )
 
+    @classmethod
+    def get_availability(cls):
+        if not federatedcode.is_configured():
+            return "FederatedCode is not configured."
+
     def check_federatedcode_eligibility(self):
         """
         Check if the project fulfills the following criteria for

--- a/scanpipe/templates/scanpipe/modals/add_pipeline_modal.html
+++ b/scanpipe/templates/scanpipe/modals/add_pipeline_modal.html
@@ -1,4 +1,4 @@
-<div id="add-pipeline-modal" class="modal">
+<div id="add-pipeline-modal" class="modal is-medium-size">
   <div class="modal-background"></div>
   {# Keep the <form> outside the .modal-card head/body/footer sections #}
   <form method="post" data-submit-overlay>{% csrf_token %}
@@ -7,16 +7,13 @@
         <p class="modal-card-title">Add pipeline</p>
         <button class="delete" type="button" aria-label="close"></button>
       </header>
-      <section class="modal-card-body">
+      <section class="modal-card-body mb-0 pb-0">
         {% if pipeline_runs %}
-          <div class="message is-info">
-            <div class="message-body">
-              <span class="icon width-1 height-1 mr-1">
-                <i class="fa-solid fa-info-circle"></i>
-              </span>
-              <span>
-                Pipeline selection is <strong>limited to add-ons</strong> as pipelines
-                have already been assigned to this project.
+          <div class="message is-info mb-3">
+            <div class="message-body p-3">
+              <span class="icon-text">
+                <span class="icon"><i class="fa-solid fa-info-circle"></i></span>
+                <span>Only <strong>add-on pipelines</strong> are available, as this project already has a base pipeline assigned.</span>
               </span>
             </div>
           </div>
@@ -25,22 +22,29 @@
           <div class="control">
             {% for pipeline_name, pipeline_info in pipeline_choices %}
               <div class="mb-3">
-                <label class="radio label mb-0">
-                  <input type="radio" name="pipeline" value="{{ pipeline_name }}">
+                <label class="radio label mb-0 {% if not pipeline_info.is_available %}has-text-grey{% endif %}">
+                  <input type="radio" name="pipeline" value="{{ pipeline_name }}"{% if not pipeline_info.is_available %} disabled{% endif %}>
                   {{ pipeline_name }}
                 </label>
-                <p class="help ml-4">{{ pipeline_info.summary }}</p>
-                {% if pipeline_info.available_groups %}
-                  <div class="ml-2 mt-1">
-                    {% for group in pipeline_info.available_groups %}
-                      <label class="checkbox ml-1 mb-1" for="id_{{ pipeline_name }}_{{ group }}">
-                        <span class="tag is-warning has-text-weight-bold">
-                          <input type="checkbox" name="selected_groups" value="{{ group }}" id="id_{{ pipeline_name }}_{{ group }}" class="mr-1">
-                          {{ group }}
-                        </span>
-                      </label>
-                    {% endfor %}
-                  </div>
+                {% if pipeline_info.is_available %}
+                  <p class="help ml-4">{{ pipeline_info.summary }}</p>
+                  {% if pipeline_info.available_groups %}
+                    <div class="ml-2 mt-1">
+                      {% for group in pipeline_info.available_groups %}
+                        <label class="checkbox ml-1 mb-1" for="id_{{ pipeline_name }}_{{ group }}">
+                          <span class="tag is-warning has-text-weight-bold">
+                            <input type="checkbox" name="selected_groups" value="{{ group }}" id="id_{{ pipeline_name }}_{{ group }}" class="mr-1">
+                            {{ group }}
+                          </span>
+                        </label>
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                {% else %}
+                  <p class="help ml-4 has-text-grey is-flex is-align-items-center">
+                    <span class="icon is-small mr-1"><i class="fa-solid fa-circle-info"></i></span>
+                    <span>{{ pipeline_info.unavailable_reason }}</span>
+                  </p>
                 {% endif %}
               </div>
             {% endfor %}

--- a/scanpipe/templates/scanpipe/modals/add_pipeline_modal.html
+++ b/scanpipe/templates/scanpipe/modals/add_pipeline_modal.html
@@ -21,17 +21,17 @@
         <div class="field">
           <div class="control">
             {% for pipeline_name, pipeline_info in pipeline_choices %}
-              <div class="mb-3">
-                <label class="radio label mb-0 {% if not pipeline_info.is_available %}has-text-grey{% endif %}">
-                  <input type="radio" name="pipeline" value="{{ pipeline_name }}"{% if not pipeline_info.is_available %} disabled{% endif %}>
-                  {{ pipeline_name }}
-                </label>
-                {% if pipeline_info.is_available %}
-                  <p class="help ml-4">{{ pipeline_info.summary }}</p>
+              {% if pipeline_info.is_available %}
+                <div class="mb-3">
+                  <label class="radio label mb-0">
+                    <input type="radio" name="pipeline" value="{{ pipeline_name }}">
+                    {{ pipeline_name }}
+                  </label>
+                  <p class="help ml-4 mt-0">{{ pipeline_info.summary }}</p>
                   {% if pipeline_info.available_groups %}
                     <div class="ml-2 mt-1">
                       {% for group in pipeline_info.available_groups %}
-                        <label class="checkbox ml-1 mb-1" for="id_{{ pipeline_name }}_{{ group }}">
+                        <label class="checkbox ml-1" for="id_{{ pipeline_name }}_{{ group }}">
                           <span class="tag is-warning has-text-weight-bold">
                             <input type="checkbox" name="selected_groups" value="{{ group }}" id="id_{{ pipeline_name }}_{{ group }}" class="mr-1">
                             {{ group }}
@@ -40,13 +40,27 @@
                       {% endfor %}
                     </div>
                   {% endif %}
-                {% else %}
-                  <p class="help ml-4 has-text-grey is-flex is-align-items-center">
-                    <span class="icon is-small mr-1"><i class="fa-solid fa-circle-info"></i></span>
-                    <span>{{ pipeline_info.unavailable_reason }}</span>
-                  </p>
-                {% endif %}
-              </div>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </div>
+        <hr class="my-2">
+        <div class="field">
+          <div class="control">
+            {% for pipeline_name, pipeline_info in pipeline_choices %}
+              {% if not pipeline_info.is_available %}
+                <div class="mb-3">
+                  <div class="is-flex is-align-items-center">
+                    <span class="has-text-grey ml-4 mr-3">{{ pipeline_name }}</span>
+                    <span class="tag is-light">
+                      <span class="icon is-small"><i class="fa-solid fa-circle-info has-text-grey"></i></span>
+                      <span class="has-text-grey ml-1">{{ pipeline_info.unavailable_reason }}</span>
+                    </span>
+                  </div>
+                  <p class="help ml-4 mt-0 has-text-grey-light">{{ pipeline_info.summary }}</p>
+                </div>
+              {% endif %}
             {% endfor %}
           </div>
         </div>

--- a/scanpipe/tests/test_api.py
+++ b/scanpipe/tests/test_api.py
@@ -706,7 +706,15 @@ class ScanPipeAPITest(TransactionTestCase):
     def test_scanpipe_api_project_action_pipelines(self):
         url = reverse("project-pipelines")
         response = self.csrf_client.get(url)
-        expected = ["name", "summary", "description", "steps", "available_groups", "is_available", "unavailable_reason"]
+        expected = [
+            "name",
+            "summary",
+            "description",
+            "steps",
+            "available_groups",
+            "is_available",
+            "unavailable_reason",
+        ]
         self.assertEqual(expected, list(response.data[0].keys()))
 
     def test_scanpipe_api_project_action_report(self):

--- a/scanpipe/tests/test_api.py
+++ b/scanpipe/tests/test_api.py
@@ -706,7 +706,7 @@ class ScanPipeAPITest(TransactionTestCase):
     def test_scanpipe_api_project_action_pipelines(self):
         url = reverse("project-pipelines")
         response = self.csrf_client.get(url)
-        expected = ["name", "summary", "description", "steps", "available_groups"]
+        expected = ["name", "summary", "description", "steps", "available_groups", "is_available", "unavailable_reason"]
         self.assertEqual(expected, list(response.data[0].keys()))
 
     def test_scanpipe_api_project_action_report(self):

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -48,6 +48,7 @@ from scanpipe.pipelines import analyze_root_filesystem
 from scanpipe.pipelines import deploy_to_develop
 from scanpipe.pipelines import is_pipeline
 from scanpipe.pipelines import scan_single_package
+from scanpipe.pipelines.find_vulnerabilities import FindVulnerabilities
 from scanpipe.pipes import d2d
 from scanpipe.pipes import flag
 from scanpipe.pipes import output
@@ -85,6 +86,8 @@ class ScanPipePipelinesTest(TestCase):
                 {"name": "step2", "doc": "Step2 doc.", "groups": []},
             ],
             "available_groups": [],
+            "is_available": True,
+            "unavailable_reason": "",
         }
         self.assertEqual(expected, DoNothing.get_info())
 
@@ -95,8 +98,68 @@ class ScanPipePipelinesTest(TestCase):
                 {"name": "step", "doc": "", "groups": []},
             ],
             "available_groups": [],
+            "is_available": True,
+            "unavailable_reason": "",
         }
         self.assertEqual(expected, ProfileStep.get_info())
+
+    def test_scanpipe_pipeline_class_get_availability_default(self):
+        self.assertIsNone(DoNothing.get_availability())
+        info = DoNothing.get_info()
+        self.assertTrue(info["is_available"])
+        self.assertEqual("", info["unavailable_reason"])
+
+    def test_scanpipe_pipeline_class_get_availability_unavailable(self):
+        class UnavailablePipeline(DoNothing):
+            @classmethod
+            def get_availability(cls):
+                return "Required service is not configured."
+
+        self.assertEqual(
+            "Required service is not configured.",
+            UnavailablePipeline.get_availability(),
+        )
+        info = UnavailablePipeline.get_info()
+        self.assertFalse(info["is_available"])
+        self.assertEqual(
+            "Required service is not configured.", info["unavailable_reason"]
+        )
+
+    def test_scanpipe_find_vulnerabilities_get_availability_not_configured(self):
+        with mock.patch(
+            "scanpipe.pipes.vulnerablecode.is_configured", return_value=False
+        ):
+            reason = FindVulnerabilities.get_availability()
+
+        self.assertEqual("VulnerableCode is not configured.", reason)
+        self.assertIsNotNone(reason)
+
+    def test_scanpipe_find_vulnerabilities_get_availability_configured(self):
+        with mock.patch(
+            "scanpipe.pipes.vulnerablecode.is_configured", return_value=True
+        ):
+            reason = FindVulnerabilities.get_availability()
+
+        self.assertIsNone(reason)
+
+    def test_scanpipe_find_vulnerabilities_get_info_availability(self):
+        with mock.patch(
+            "scanpipe.pipes.vulnerablecode.is_configured", return_value=False
+        ):
+            info = FindVulnerabilities.get_info()
+
+        self.assertFalse(info["is_available"])
+        self.assertEqual(
+            "VulnerableCode is not configured.", info["unavailable_reason"]
+        )
+
+        with mock.patch(
+            "scanpipe.pipes.vulnerablecode.is_configured", return_value=True
+        ):
+            info = FindVulnerabilities.get_info()
+
+        self.assertTrue(info["is_available"])
+        self.assertEqual("", info["unavailable_reason"])
 
     def test_scanpipe_pipeline_class_get_summary(self):
         expected = "Do nothing, in 2 steps."

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -1872,8 +1872,9 @@ class PipelinesIntegrationTest(TestCase):
 
     @mock.patch("scanpipe.pipes.purldb.request_post")
     @mock.patch("scanpipe.pipes.purldb.is_available")
+    @mock.patch("scanpipe.pipes.purldb.is_configured", return_value=True)
     def test_scanpipe_populate_purldb_pipeline_integration(
-        self, mock_is_available, mock_request_post
+        self, mock_is_configured, mock_is_available, mock_request_post
     ):
         pipeline_name1 = "load_inventory"
         pipeline_name2 = "populate_purldb"
@@ -1915,8 +1916,9 @@ class PipelinesIntegrationTest(TestCase):
 
     @mock.patch("scanpipe.pipes.purldb.request_post")
     @mock.patch("scanpipe.pipes.purldb.is_available")
+    @mock.patch("scanpipe.pipes.purldb.is_configured", return_value=True)
     def test_scanpipe_populate_purldb_pipeline_integration_without_assembly(
-        self, mock_is_available, mock_request_post
+        self, mock_is_configured, mock_is_available, mock_request_post
     ):
         pipeline_name = "populate_purldb"
         project1 = make_project()


### PR DESCRIPTION
## Changes

- Add `get_availability()` classmethod to Pipeline returning None (available) or a reason string (unavailable)
- Implement `get_availability()` on FindVulnerabilities, EnrichWithPurlDB, PopulatePurlDB, MatchToMatchCode, PublishToFederatedCode, and FetchScores
- Update the add pipeline modal to show available pipelines first, unavailable below a separator with their reason
