### PR TITLE
fix: harden SSRF mitigation against redirect and URL-parser bypasses

### DIFF
--- a/scanpipe/pipes/fetch.py
+++ b/scanpipe/pipes/fetch.py
@@ -30,12 +30,14 @@ import tempfile
 from collections import namedtuple
 from pathlib import Path
 from urllib.parse import unquote
+from urllib.parse import urljoin
 from urllib.parse import urlparse
 
 from django.utils.http import parse_header_parameters
 
 import git
 import requests
+import urllib3
 from commoncode import command
 from commoncode.hash import multi_checksums
 from commoncode.text import python_safe_name
@@ -64,6 +66,18 @@ Download = namedtuple("Download", "uri directory filename path size sha1 md5")
 # certain conditions.
 HTTP_REQUEST_TIMEOUT = 30
 
+# Maximum number of HTTP redirects to follow when fetching a URL, re-validating
+# the target of each hop with ``is_safe_url`` to prevent a safe URL from
+# redirecting the request to an internal address.
+MAX_REDIRECT_HOPS = 5
+
+REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+
+# Backslash and control/whitespace characters can make ``urlparse`` and the
+# urllib3-based HTTP client disagree on the host part of a URL, defeating the
+# ``is_safe_url`` check below.
+UNSAFE_URL_CHARS_RE = re.compile(r"[\x00-\x20\x7f\\]")
+
 
 def get_request_session(uri):
     """Return a Requests session setup with authentication and headers."""
@@ -87,8 +101,7 @@ def fetch_http(uri, to=None):
     Download a given `uri` in a temporary directory and return the directory's
     path.
     """
-    request_session = get_request_session(uri)
-    response = request_session.get(uri, timeout=HTTP_REQUEST_TIMEOUT)
+    response = _request_with_safe_redirects(uri, "get")
 
     if response.status_code != 200:
         raise requests.RequestException
@@ -413,42 +426,81 @@ def is_safe_url(url):
     Check that a URL does not point to a private or internal network address.
     Mitigates SSRF by ensuring the target host resolves only to public IPs.
     """
-    parsed = urlparse(url)
-
-    # Only allow http and https schemes
-    if parsed.scheme not in ("http", "https"):
+    # Reject characters that can make `urlparse` and the urllib3-based HTTP
+    # client disagree on the host part of the same URL.
+    if UNSAFE_URL_CHARS_RE.search(url):
         return False
 
-    # Reject URLs with no hostname
-    if not parsed.hostname:
+    if urlparse(url).scheme not in ("http", "https"):
         return False
 
-    # Resolve the hostname to catch internal addresses hidden behind DNS
+    # Use urllib3's own URL parser, the one `requests` relies on to pick a
+    # connection host, so this check and the actual request always agree on
+    # which host is being contacted.
+    host = urllib3.util.parse_url(url).host
+    if not host:
+        return False
+
+    # Resolve the hostname to catch internal addresses hidden behind DNS.
+    # `getaddrinfo` is used instead of `gethostbyname` to also cover IPv6-only
+    # records, since a client may connect over either address family.
     try:
-        resolved_ip = socket.gethostbyname(parsed.hostname)
+        address_infos = socket.getaddrinfo(host, None)
     except socket.gaierror:
         return False
 
-    # Reject private, loopback, link-local, and reserved addresses
-    ip = ipaddress.ip_address(resolved_ip)
-    unsafe = (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_reserved
-        or ip.is_multicast
-    )
-    return not unsafe
+    resolved_ips = {address_info[4][0] for address_info in address_infos}
+    if not resolved_ips:
+        return False
+
+    # Reject private, loopback, link-local, reserved, and multicast addresses.
+    # If any resolved address is unsafe, the host is rejected since the HTTP
+    # client is free to connect to any of them.
+    for resolved_ip in resolved_ips:
+        ip = ipaddress.ip_address(resolved_ip)
+        unsafe = (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+        )
+        if unsafe:
+            return False
+
+    return True
+
+
+def _request_with_safe_redirects(url, method_name):
+    """
+    Perform an HTTP request for `url` using the session `method_name`
+    ("get" or "head"), re-validating each redirect target with `is_safe_url`
+    before following it.
+    Raise `requests.RequestException` if the URL, or any redirect target, is
+    unsafe or if too many redirects are followed.
+    """
+    request_session = get_request_session(url)
+    session_method = getattr(request_session, method_name)
+
+    for _ in range(MAX_REDIRECT_HOPS + 1):
+        if not is_safe_url(url):
+            raise requests.RequestException(f"Unsafe URL: {url}")
+
+        response = session_method(
+            url, timeout=HTTP_REQUEST_TIMEOUT, allow_redirects=False
+        )
+        if response.status_code not in REDIRECT_STATUS_CODES:
+            return response
+
+        url = urljoin(url, response.headers["location"])
+
+    raise requests.RequestException("Too many redirects.")
 
 
 def check_url(url):
     """Check that a URL is safe and accessible."""
-    if not is_safe_url(url):
-        return False
-
-    request_session = get_request_session(url)
     try:
-        response = request_session.head(url, timeout=HTTP_REQUEST_TIMEOUT)
+        response = _request_with_safe_redirects(url, "head")
         response.raise_for_status()
     except requests.exceptions.RequestException:
         return False

--- a/scanpipe/tests/pipes/test_fetch.py
+++ b/scanpipe/tests/pipes/test_fetch.py
@@ -73,8 +73,9 @@ class ScanPipeFetchPipesTest(TestCase):
         expected = "SSH 'git@' URLs are not supported. Use https:// instead."
         self.assertEqual(expected, str(cm.exception))
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("requests.sessions.Session.get")
-    def test_scanpipe_pipes_fetch_http(self, mock_get):
+    def test_scanpipe_pipes_fetch_http(self, mock_get, mock_is_safe_url):
         url = "https://example.com/filename.zip"
 
         mock_get.return_value = make_mock_response(url=url)
@@ -93,8 +94,9 @@ class ScanPipeFetchPipesTest(TestCase):
         downloaded_file = fetch.fetch_http(url)
         self.assertTrue(Path(downloaded_file.directory, "another_name.zip").exists())
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("requests.sessions.Session.get")
-    def test_scanpipe_pipes_fetch_package_url(self, mock_get):
+    def test_scanpipe_pipes_fetch_package_url(self, mock_get, mock_is_safe_url):
         package_url = "pkg:not_a_valid_purl"
         with self.assertRaises(ValueError) as cm:
             fetch.fetch_package_url(package_url)
@@ -112,9 +114,12 @@ class ScanPipeFetchPipesTest(TestCase):
         downloaded_file = fetch.fetch_package_url(package_url)
         self.assertTrue(Path(downloaded_file.directory, "filename.zip").exists())
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("fetchcode.pypi.fetch_json_response")
     @mock.patch("requests.sessions.Session.get")
-    def test_scanpipe_pipes_fetch_pypi_package_url(self, mock_get, mock_fetch_json):
+    def test_scanpipe_pipes_fetch_pypi_package_url(
+        self, mock_get, mock_fetch_json, mock_is_safe_url
+    ):
         package_url = "pkg:pypi/django@5.2"
         download_url = "https://files.pythonhosted.org/packages/Django-5.2.tar.gz"
 
@@ -213,8 +218,9 @@ class ScanPipeFetchPipesTest(TestCase):
             fetch.fetch_docker_image(url)
         self.assertEqual("Invalid Docker reference.", str(cm.exception))
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("requests.sessions.Session.get")
-    def test_scanpipe_pipes_fetch_fetch_urls(self, mock_get):
+    def test_scanpipe_pipes_fetch_fetch_urls(self, mock_get, mock_is_safe_url):
         urls = [
             "https://example.com/filename.zip",
             "https://example.com/archive.tar.gz",
@@ -269,10 +275,22 @@ class ScanPipeFetchPipesTest(TestCase):
         self.assertEqual("", download.sha1)
         self.assertEqual("", download.md5)
 
-    @mock.patch("scanpipe.pipes.fetch.socket.gethostbyname")
-    def test_scanpipe_pipes_fetch_is_safe_url(self, mock_gethostbyname):
+    @staticmethod
+    def make_addrinfo(*ips):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+    @staticmethod
+    def make_addrinfo6(*ips):
+        return [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", (ip, 0, 0, 0)) for ip in ips
+        ]
+
+    @mock.patch("scanpipe.pipes.fetch.socket.getaddrinfo")
+    def test_scanpipe_pipes_fetch_is_safe_url(self, mock_getaddrinfo):
         # Valid public URLs
-        mock_gethostbyname.return_value = "93.184.216.34"  # example.com
+        mock_getaddrinfo.return_value = self.make_addrinfo(
+            "93.184.216.34"
+        )  # example.com
         self.assertTrue(fetch.is_safe_url("https://example.com/file.zip"))
         self.assertTrue(fetch.is_safe_url("http://example.com/file.zip"))
 
@@ -285,55 +303,101 @@ class ScanPipeFetchPipesTest(TestCase):
         self.assertFalse(fetch.is_safe_url("https://"))
 
         # Unresolvable hostname
-        mock_gethostbyname.side_effect = socket.gaierror
+        mock_getaddrinfo.side_effect = socket.gaierror
         self.assertFalse(fetch.is_safe_url("https://thisdomaindoesnotexist.invalid/"))
-        mock_gethostbyname.side_effect = None
+        mock_getaddrinfo.side_effect = None
 
         # Private ranges
-        mock_gethostbyname.return_value = "192.168.1.1"
+        mock_getaddrinfo.return_value = self.make_addrinfo("192.168.1.1")
         self.assertFalse(fetch.is_safe_url("http://192.168.1.1/"))
-        mock_gethostbyname.return_value = "10.0.0.1"
+        mock_getaddrinfo.return_value = self.make_addrinfo("10.0.0.1")
         self.assertFalse(fetch.is_safe_url("http://10.0.0.1/"))
-        mock_gethostbyname.return_value = "172.16.0.1"
+        mock_getaddrinfo.return_value = self.make_addrinfo("172.16.0.1")
         self.assertFalse(fetch.is_safe_url("http://172.16.0.1/"))
 
         # Loopback
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = self.make_addrinfo("127.0.0.1")
         self.assertFalse(fetch.is_safe_url("http://127.0.0.1/"))
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = self.make_addrinfo("127.0.0.1")
         self.assertFalse(fetch.is_safe_url("http://localhost/"))
 
         # Link-local
-        mock_gethostbyname.return_value = "169.254.169.254"
+        mock_getaddrinfo.return_value = self.make_addrinfo("169.254.169.254")
         self.assertFalse(fetch.is_safe_url("http://169.254.169.254/"))
 
         # Multicast
-        mock_gethostbyname.return_value = "224.0.0.1"
+        mock_getaddrinfo.return_value = self.make_addrinfo("224.0.0.1")
         self.assertFalse(fetch.is_safe_url("http://224.0.0.1/"))
 
-    @mock.patch("scanpipe.pipes.fetch.socket.gethostbyname")
+        # One of several resolved addresses is unsafe
+        mock_getaddrinfo.return_value = self.make_addrinfo("93.184.216.34", "127.0.0.1")
+        self.assertFalse(fetch.is_safe_url("http://example.com/file.zip"))
+
+        # A backslash before the "real" host can make `urlparse` and the
+        # urllib3-based HTTP client disagree on which host is contacted.
+        self.assertFalse(fetch.is_safe_url("http://127.0.0.1\\@example.com/"))
+
+        # Control characters (e.g. from a CRLF-injection attempt) are rejected
+        # wherever they appear in the URL.
+        self.assertFalse(fetch.is_safe_url("http://example.com/\x00file.zip"))
+        self.assertFalse(fetch.is_safe_url("http://example.com/\r\nfile.zip"))
+
+        # IPv6 loopback and link-local addresses are rejected, and a safe
+        # public IPv6-only host is accepted.
+        mock_getaddrinfo.return_value = self.make_addrinfo6("::1")
+        self.assertFalse(fetch.is_safe_url("http://example.com/file.zip"))
+        mock_getaddrinfo.return_value = self.make_addrinfo6("fe80::1")
+        self.assertFalse(fetch.is_safe_url("http://example.com/file.zip"))
+        mock_getaddrinfo.return_value = self.make_addrinfo6("2606:4700:4700::1111")
+        self.assertTrue(fetch.is_safe_url("http://example.com/file.zip"))
+
+    @mock.patch("scanpipe.pipes.fetch.socket.getaddrinfo")
     @mock.patch("requests.sessions.Session.head")
-    def test_scanpipe_pipes_fetch_check_url(self, mock_head, mock_gethostbyname):
+    def test_scanpipe_pipes_fetch_check_url(self, mock_head, mock_getaddrinfo):
         url = "https://example.com/file.zip"
 
         # Safe and accessible URL
-        mock_gethostbyname.return_value = "93.184.216.34"
+        mock_getaddrinfo.return_value = self.make_addrinfo("93.184.216.34")
         mock_head.return_value = make_mock_response(url=url)
         self.assertTrue(fetch.check_url(url))
 
         # Unsafe URL
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = self.make_addrinfo("127.0.0.1")
         self.assertFalse(fetch.check_url("http://localhost/"))
 
         # Safe URL but request fails
-        mock_gethostbyname.return_value = "93.184.216.34"
+        mock_getaddrinfo.return_value = self.make_addrinfo("93.184.216.34")
         mock_head.side_effect = requests.exceptions.RequestException
         self.assertFalse(fetch.check_url(url))
 
-    @mock.patch("scanpipe.pipes.fetch.socket.gethostbyname")
+    def test_scanpipe_pipes_fetch_check_url_rejects_redirect_to_unsafe_host(self):
+        def getaddrinfo(host, *args, **kwargs):
+            if host == "127.0.0.1":
+                return self.make_addrinfo("127.0.0.1")
+            return self.make_addrinfo("93.184.216.34")
+
+        url = "https://example.com/file.zip"
+        redirect_response = make_mock_response(
+            url=url,
+            status_code=302,
+            headers={"location": "http://127.0.0.1/internal"},
+        )
+
+        with (
+            mock.patch(
+                "scanpipe.pipes.fetch.socket.getaddrinfo", side_effect=getaddrinfo
+            ),
+            mock.patch(
+                "requests.sessions.Session.head", return_value=redirect_response
+            ) as mock_head,
+        ):
+            self.assertFalse(fetch.check_url(url))
+            self.assertEqual(1, mock_head.call_count)
+
+    @mock.patch("scanpipe.pipes.fetch.socket.getaddrinfo")
     @mock.patch("requests.sessions.Session.head")
     def test_scanpipe_pipes_fetch_check_urls_availability(
-        self, mock_head, mock_gethostbyname
+        self, mock_head, mock_getaddrinfo
     ):
         http_urls = [
             "https://example.com/file.zip",
@@ -345,13 +409,134 @@ class ScanPipeFetchPipesTest(TestCase):
         ]
 
         # All URLs safe and accessible
-        mock_gethostbyname.return_value = "93.184.216.34"
+        mock_getaddrinfo.return_value = self.make_addrinfo("93.184.216.34")
         mock_head.return_value = make_mock_response(url="mocked_url")
         self.assertEqual([], fetch.check_urls_availability(urls))
 
         # All URLs fail
         mock_head.side_effect = requests.exceptions.RequestException
         self.assertEqual(http_urls, fetch.check_urls_availability(urls))
+
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url")
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_request_with_safe_redirects_revalidates_redirects(
+        self, mock_get, mock_is_safe_url
+    ):
+        safe_url = "https://example.com/"
+        unsafe_redirect_url = "http://127.0.0.1/internal"
+        mock_is_safe_url.side_effect = lambda url: url == safe_url
+
+        mock_get.return_value = make_mock_response(
+            url=safe_url, status_code=302, headers={"location": unsafe_redirect_url}
+        )
+
+        with self.assertRaises(requests.RequestException):
+            fetch._request_with_safe_redirects(safe_url, "get")
+
+        mock_is_safe_url.assert_any_call(unsafe_redirect_url)
+
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_request_with_safe_redirects_follows_safe_redirect(
+        self, mock_get, mock_is_safe_url
+    ):
+        first_url = "https://example.com/"
+        final_url = "https://example.com/final"
+
+        redirect_response = make_mock_response(
+            url=first_url, status_code=302, headers={"location": final_url}
+        )
+        final_response = make_mock_response(url=final_url)
+        mock_get.side_effect = [redirect_response, final_response]
+
+        response = fetch._request_with_safe_redirects(first_url, "get")
+        self.assertEqual(final_response, response)
+        self.assertEqual(2, mock_get.call_count)
+
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_request_with_safe_redirects_relative_location(
+        self, mock_get, mock_is_safe_url
+    ):
+        first_url = "https://example.com/downloads/"
+        final_url = "https://example.com/downloads/final.zip"
+
+        redirect_response = make_mock_response(
+            url=first_url, status_code=302, headers={"location": "final.zip"}
+        )
+        final_response = make_mock_response(url=final_url)
+        mock_get.side_effect = [redirect_response, final_response]
+
+        response = fetch._request_with_safe_redirects(first_url, "get")
+        self.assertEqual(final_response, response)
+        mock_is_safe_url.assert_any_call(final_url)
+
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_request_with_safe_redirects_too_many_redirects(
+        self, mock_get, mock_is_safe_url
+    ):
+        url = "https://example.com/"
+        mock_get.return_value = make_mock_response(
+            url=url, status_code=302, headers={"location": url}
+        )
+
+        with self.assertRaises(requests.RequestException):
+            fetch._request_with_safe_redirects(url, "get")
+        self.assertEqual(fetch.MAX_REDIRECT_HOPS + 1, mock_get.call_count)
+
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_request_with_safe_redirects_max_hops_allowed(
+        self, mock_get, mock_is_safe_url
+    ):
+        url = "https://example.com/"
+        redirect_response = make_mock_response(
+            url=url, status_code=302, headers={"location": url}
+        )
+        final_response = make_mock_response(url=url)
+        # One redirect response per hop, then a final non-redirect response.
+        mock_get.side_effect = [redirect_response] * fetch.MAX_REDIRECT_HOPS + [
+            final_response
+        ]
+
+        response = fetch._request_with_safe_redirects(url, "get")
+        self.assertEqual(final_response, response)
+        self.assertEqual(fetch.MAX_REDIRECT_HOPS + 1, mock_get.call_count)
+
+    @mock.patch("scanpipe.pipes.fetch.socket.getaddrinfo")
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_http_rejects_unsafe_url(
+        self, mock_get, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = self.make_addrinfo("127.0.0.1")
+
+        with self.assertRaises(requests.RequestException):
+            fetch.fetch_http("http://127.0.0.1/internal")
+        mock_get.assert_not_called()
+
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_http_rejects_parser_differential_bypass(
+        self, mock_get
+    ):
+        # Same payload as the SSRF advisory: `urlparse` and the urllib3-based
+        # HTTP client would otherwise disagree on which host is contacted.
+        with self.assertRaises(requests.RequestException):
+            fetch.fetch_http("http://127.0.0.1:8081\\@8.8.8.8/")
+        mock_get.assert_not_called()
+
+    @mock.patch("scanpipe.pipes.fetch.socket.getaddrinfo")
+    @mock.patch("scanpipe.pipes.fetch.purl2url.get_download_url")
+    @mock.patch("requests.sessions.Session.get")
+    def test_scanpipe_pipes_fetch_package_url_rejects_unsafe_download_url(
+        self, mock_get, mock_get_download_url, mock_getaddrinfo
+    ):
+        mock_get_download_url.return_value = "http://127.0.0.1/evil.tar.gz"
+        mock_getaddrinfo.return_value = self.make_addrinfo("127.0.0.1")
+
+        with self.assertRaises(requests.RequestException):
+            fetch.fetch_package_url("pkg:npm/d3@5.8.0")
+        mock_get.assert_not_called()
 
     def test_scanpipe_pipes_fetch_set_project_purl_from_input_url(self):
         project = Project.objects.create(name="purl_from_url")

--- a/scanpipe/tests/test_commands.py
+++ b/scanpipe/tests/test_commands.py
@@ -1047,10 +1047,11 @@ class ScanPipeManagementCommandTest(TestCase):
         self.assertEqual("do_nothing", runs[1]["pipeline_name"])
         self.assertEqual(["Group1", "Group2"], runs[1]["selected_groups"])
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("scanpipe.pipes.fetch.check_url")
     @mock.patch("requests.sessions.Session.get")
     def test_scanpipe_management_command_run_multiple_inputs(
-        self, mock_get, mock_check_url
+        self, mock_get, mock_check_url, mock_is_safe_url
     ):
         mock_check_url.return_value = True
         source_download_url = "https://example.com/z-source.zip#from"

--- a/scanpipe/tests/test_forms.py
+++ b/scanpipe/tests/test_forms.py
@@ -44,8 +44,11 @@ class ScanPipeFormsTest(TestCase):
     def setUp(self):
         self.project1 = Project.objects.create(name="Analysis")
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("requests.sessions.Session.head")
-    def test_scanpipe_forms_inputs_base_form_input_urls(self, mock_head):
+    def test_scanpipe_forms_inputs_base_form_input_urls(
+        self, mock_head, mock_is_safe_url
+    ):
         data = {
             "input_urls": "Docker://debian",
         }
@@ -252,8 +255,11 @@ class ScanPipeFormsTest(TestCase):
         obj = form2.save()
         self.assertEqual("pkg:npm/lodash@4.17.21", obj.purl)
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("requests.sessions.Session.head")
-    def test_scanpipe_forms_handle_inputs_auto_fill_purl(self, mock_head):
+    def test_scanpipe_forms_handle_inputs_auto_fill_purl(
+        self, mock_head, mock_is_safe_url
+    ):
         mock_head.return_value = mock.Mock(headers={}, status_code=200)
         lodash_url = "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
 

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -1582,9 +1582,12 @@ class ScanPipeModelsTest(TestCase):
         input_source.delete_file()
         self.assertFalse(input_source.exists())
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("scanpipe.pipes.fetch.check_url")
     @mock.patch("requests.sessions.Session.get")
-    def test_scanpipe_input_source_model_fetch(self, mock_get, mock_check_url):
+    def test_scanpipe_input_source_model_fetch(
+        self, mock_get, mock_check_url, mock_is_safe_url
+    ):
         download_url = "https://download.url/file.zip"
         mock_get.return_value = make_mock_response(url=download_url)
         mock_check_url.return_value = True

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -268,10 +268,11 @@ class ScanPipePipelinesTest(TestCase):
         pipeline.execute()
         self.assertNotIn("Step [download_missing_inputs]", run.log)
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("scanpipe.pipes.fetch.check_url")
     @mock.patch("requests.sessions.Session.get")
     def test_scanpipe_pipeline_class_download_missing_inputs(
-        self, mock_get, mock_check_url
+        self, mock_get, mock_check_url, mock_is_safe_url
     ):
         mock_check_url.return_value = True
         project1 = make_project()

--- a/scanpipe/tests/test_views.py
+++ b/scanpipe/tests/test_views.py
@@ -316,8 +316,11 @@ class ScanPipeViewsTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, expected1)
 
+    @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("requests.sessions.Session.head")
-    def test_scanpipe_views_project_details_add_inputs(self, mock_head):
+    def test_scanpipe_views_project_details_add_inputs(
+        self, mock_head, mock_is_safe_url
+    ):
         url = self.project1.get_absolute_url()
 
         data = {


### PR DESCRIPTION
`is_safe_url()` resolved the host with `urlparse()` while requests/urllib3 connect using their own parser, letting a crafted authority (e.g. a backslash before an "@") pass validation while the actual connection went to a different, internal host. 
DNS resolution was also IPv4-only, and `fetch_http()` never re-validated redirect targets, so a safe URL could 302 to an internal address after the check had already passed.

- `is_safe_url()` now resolves the host via `urllib3.util.parse_url()`, the parser requests actually uses to connect, and rejects backslash/ control characters up front.
- DNS resolution uses `getaddrinfo()` (IPv4 + IPv6), rejecting the host if any resolved address is private/loopback/link-local/reserved/multicast.
- `fetch_http()` and `check_url()` now share `_request_with_safe_redirects()`, which re-validates every redirect hop before following it.
- `fetch_http()` performs its own safety check instead of relying solely on the caller, closing a gap where pkg: URLs resolved via `fetch_package_url()` were never validated.
