### PR TITLE
fix: The `web` service in docker-compose.yml had no healthcheck, so

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,13 @@ services:
     ports:
       # Port 8001 to avoid conflict when running side-by-side with dejacode on 8000
       - "8001:8001"
+    # Override the base healthcheck to target the dev runserver port.
+    healthcheck:
+      test: ["CMD", "wait-for-it", "--timeout=2", "localhost:8001"]
+      interval: 10s
+      timeout: 5s
+      retries: 48
+      start_period: 120s
 
   # Volume mount keeps code in sync. Restart manually with: make restart-worker
   worker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,16 @@ services:
       - workspace:/var/scancodeio/workspace/
       - static:/var/scancodeio/static/
     restart: always
+    # Without a healthcheck, "docker compose up --wait" only waits for the
+    # container to be running, not for migrate/collectstatic to complete, so
+    # commands relying on the database schema (e.g. `docker compose run web
+    # scanpipe ...`) can race ahead of the migrations.
+    healthcheck:
+      test: ["CMD", "wait-for-it", "--timeout=2", "localhost:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 48
+      start_period: 120s
     depends_on:
       db:
         condition: service_healthy

--- a/scanpipe/tests/test_scancodeio.py
+++ b/scanpipe/tests/test_scancodeio.py
@@ -22,6 +22,9 @@
 
 from django.test import TestCase
 
+import yaml
+
+from scancodeio import ROOT_DIR
 from scancodeio import extract_short_commit
 
 
@@ -32,3 +35,13 @@ class ScanCodeIOTest(TestCase):
         self.assertEqual(extract_short_commit("v1.0.0-1-g123456"), "123456")
         self.assertEqual(extract_short_commit("v2.0.0-5-abcdefg"), "abcdefg")
         self.assertEqual(extract_short_commit("v1.5.0-2-ghijkl"), "hijkl")
+
+    def test_scancodeio_docker_compose_web_service_has_healthcheck(self):
+        # Without a healthcheck, `docker compose up --wait` only waits for the
+        # "web" container to be running, not for its migrate/collectstatic
+        # steps to complete. This lets a `docker compose run web scanpipe ...`
+        # command race ahead of the database migrations.
+        # See https://github.com/aboutcode-org/scancode.io/issues/1842
+        compose_file = ROOT_DIR.joinpath("docker-compose.yml")
+        compose_data = yaml.safe_load(compose_file.read_text())
+        self.assertIn("healthcheck", compose_data["services"]["web"])


### PR DESCRIPTION
Fixes #1842

## Summary
The `web` service in docker-compose.yml had no healthcheck, so `docker compose up -d --wait` only waited for the container to be running, not for its migrate/collectstatic steps to finish, letting a subsequent `docker compose run --rm web scanpipe ...` race ahead of the DB schema (issue #1842's 'relation scanpipe_project does not exist'). Added a wait-for-it-based healthcheck to `web` (with a port-8001 override in docker-compose.dev.yml) so `--wait` truly waits for readiness, and added a regression test asserting the web service defines a healthcheck.

## Changes
- `docker-compose.yml`
- `docker-compose.dev.yml`
- `scanpipe/tests/test_scancodeio.py`

## How this was tested
Ran `the affected tests` locally.
